### PR TITLE
Add editorial landing page (GitHub Pages)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.claude/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -19,10 +19,17 @@ This repo is intentionally generic. It does **not** include private overlays, pe
 ```text
 stop-slop-refined/
 ├── SKILL.md
+├── docs/
+│   ├── site-data.js
+│   ├── index.html
+│   ├── app.js
+│   └── styles.css
 ├── references/
 │   ├── words.md
 │   ├── patterns.md
 │   └── examples.md
+├── scripts/
+│   └── generate-site-data.mjs
 ├── ATTRIBUTION.md
 ├── LICENSE
 └── README.md
@@ -68,6 +75,14 @@ Examples:
 - no personal voice layer
 - no private company context
 - no influencer-style fluff in the skill itself
+
+## Maintaining the site data
+
+If you change `references/words.md` or `references/patterns.md`, regenerate the site data:
+
+```bash
+node scripts/generate-site-data.mjs
+```
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repo is intentionally generic. It does **not** include private overlays, pe
 ## Repo contents
 
 ```text
-stop-slop-public/
+stop-slop-refined/
 ├── SKILL.md
 ├── references/
 │   ├── words.md
@@ -34,14 +34,14 @@ stop-slop-public/
 
 ```bash
 mkdir -p ~/.claude/skills
-cp -R stop-slop-public ~/.claude/skills/stop-slop
+git clone https://github.com/welttowelt/stop-slop-refined.git ~/.claude/skills/stop-slop
 ```
 
 ### Codex
 
 ```bash
 mkdir -p ~/.codex/skills
-cp -R stop-slop-public ~/.codex/skills/stop-slop
+git clone https://github.com/welttowelt/stop-slop-refined.git ~/.codex/skills/stop-slop
 ```
 
 ### ChatGPT or Claude projects

--- a/docs/app.js
+++ b/docs/app.js
@@ -6,7 +6,7 @@
    ===================================================== */
 
 (() => {
-  // ---------- data pulled from references (verbatim entries) ----------
+  // ---------- curated subset used by the browser demo ----------
 
   const TIER_1 = [
     ["delve", "explore"], ["delve into", "look at"],
@@ -466,7 +466,7 @@
     const { flags, tierCounts, words } = res;
     const density = words ? flags / words : 0;
     if (flags === 0) {
-      return `<span class="score-clean">clean.</span>&nbsp;no common patterns caught. still read it yourself.`;
+      return `<span class="score-clean">clean on this pass.</span>&nbsp;the demo did not catch anything in its subset. still read it yourself.`;
     }
     const bits = [];
     if (tierCounts.t1) bits.push(`${tierCounts.t1} tier-1 word${tierCounts.t1 > 1 ? "s" : ""}`);
@@ -476,7 +476,7 @@
     const severity = density > 0.06 || tierCounts.pat >= 3 || tierCounts.t1 >= 4
       ? `<span class="score-strong">clear ai smell.</span>`
       : `<span class="score-neutral">mixed.</span>`;
-    return `${severity}&nbsp;${bits.join(" · ")}. rewrite recommended.`;
+    return `${severity}&nbsp;${bits.join(" · ")} in the demo subset. full review still recommended.`;
   }
 
   function updateDetector() {

--- a/docs/app.js
+++ b/docs/app.js
@@ -466,7 +466,7 @@
     const { flags, tierCounts, words } = res;
     const density = words ? flags / words : 0;
     if (flags === 0) {
-      return `<span class="score-clean">clean.</span>&nbsp;no common ai patterns caught. worth a human read anyway.`;
+      return `<span class="score-clean">clean.</span>&nbsp;no common patterns caught. still read it yourself.`;
     }
     const bits = [];
     if (tierCounts.t1) bits.push(`${tierCounts.t1} tier-1 word${tierCounts.t1 > 1 ? "s" : ""}`);

--- a/docs/app.js
+++ b/docs/app.js
@@ -1,179 +1,32 @@
 /* =====================================================
    stop slop — app.js
-   powers: theme toggle, hero demo cycle, live detector,
+   powers: theme toggle, hero demo cycle, quick detector,
            examples renderer, tier/pattern renderers,
            install tabs, copy buttons
    ===================================================== */
 
 (() => {
-  // ---------- curated subset used by the browser demo ----------
+  // ---------- canonical site data generated from references/*.md ----------
 
-  const TIER_1 = [
-    ["delve", "explore"], ["delve into", "look at"],
-    ["utilize", "use"],
-    ["robust", "strong"],
-    ["comprehensive", "complete"],
-    ["pivotal", "important"],
-    ["transformative", "describe what changed"],
-    ["landscape", "field"],
-    ["tapestry", "name the complexity"],
-    ["paradigm", "model"],
-    ["embark", "start"],
-    ["beacon", "rewrite"],
-    ["testament to", "shows"],
-    ["seamless", "smooth"],
-    ["impactful", "effective"],
-    ["actionable", "concrete"],
-    ["thought leader", "expert"],
-    ["best practices", "what works"],
-    ["in order to", "to"],
-    ["due to the fact that", "because"],
-    ["serves as", "is"],
-    ["boasts", "has"],
-    ["commence", "start"],
-    ["ascertain", "find out"],
-    ["endeavor", "effort"],
-    ["deep dive", "look at"],
-    ["unpack", "explain"],
-    ["ever-evolving", "changing"],
-    ["watershed moment", "turning point"],
-    ["at its core", "cut it"]
-  ];
+  const DATA = window.STOP_SLOP_DATA;
+  if (!DATA) throw new Error("STOP_SLOP_DATA is missing. Load site-data.js before app.js.");
 
-  const TIER_2 = [
-    ["harness", "use"],
-    ["navigate", "handle"],
-    ["elevate", "improve"],
-    ["empower", "enable"],
-    ["streamline", "simplify"],
-    ["bolster", "strengthen"],
-    ["spearhead", "lead"],
-    ["resonate", "connect"],
-    ["ecosystem", "network"],
-    ["myriad", "many"],
-    ["plethora", "many"],
-    ["encompass", "include"],
-    ["catalyze", "trigger"],
-    ["cultivate", "build"],
-    ["illuminate", "clarify"],
-    ["cornerstone", "foundation"],
-    ["paramount", "most important"],
-    ["poised", "ready"],
-    ["nascent", "early"],
-    ["overarching", "broad"],
-    ["augment", "add to"]
-  ];
+  const TIER_1 = DATA.tier1;
+  const TIER_2 = DATA.tier2;
+  const TIER_3 = DATA.tier3;
+  const OPENERS = DATA.openers;
+  const FILLERS = DATA.fillers;
+  const PATTERNS = DATA.patterns;
+  const DETECTOR_PATTERNS = (DATA.detectorPatterns || []).map(({ label, source, flags }) => ({
+    label,
+    re: new RegExp(source, flags)
+  }));
 
-  const TIER_3 = [
-    "significant", "effective", "dynamic", "scalable", "compelling",
-    "valuable", "key", "vital", "remarkable", "sophisticated"
-  ];
-
-  const OPENERS = [
-    "Certainly,", "Absolutely,", "Of course,", "Great question,",
-    "Moreover,", "Furthermore,", "Additionally,", "Importantly,", "Interestingly,"
-  ];
-
-  const FILLERS = [
-    "Here's the thing", "It turns out", "The truth is", "Let me be clear",
-    "It's worth noting", "At the end of the day", "When it comes to",
-    "In today's", "The future looks bright", "Only time will tell",
-    "As we move forward", "I hope this helps", "Let me know if",
-    "Without further ado", "In conclusion", "In summary"
-  ];
-
-  const PATTERNS = [
-    {
-      group: "sentence",
-      title: "binary contrast",
-      egHtml: `<code>not x, but y</code> · <code>the real issue is not x. it's y.</code>`,
-      fix: "state y directly."
-    },
-    {
-      group: "sentence",
-      title: "negative listing",
-      egHtml: `<code>not a tool. not a workflow. a mindset.</code>`,
-      fix: "say the actual point without the runway."
-    },
-    {
-      group: "sentence",
-      title: "rhetorical question transition",
-      egHtml: `<code>so why does this matter?</code> · <code>but what does this mean for teams?</code>`,
-      fix: "if you know the answer, say it."
-    },
-    {
-      group: "sentence",
-      title: "signposting",
-      egHtml: `<code>let's dive in</code> · <code>in this section</code> · <code>here's what you need to know</code>`,
-      fix: "cut the announcement and start with the point."
-    },
-    {
-      group: "sentence",
-      title: "reasoning-chain leakage",
-      egHtml: `<code>let me think step by step</code> · <code>working through this logically</code>`,
-      fix: "give the conclusion, then the reasoning."
-    },
-    {
-      group: "structural",
-      title: "rule of three everywhere",
-      egHtml: `too many triads make writing feel generated.`,
-      fix: "use one, two, or four when that fits better."
-    },
-    {
-      group: "structural",
-      title: "uniform sentence length",
-      egHtml: `three even sentences in a row is one of the clearest ai signals.`,
-      fix: "vary rhythm on purpose."
-    },
-    {
-      group: "structural",
-      title: "uniform paragraph shape",
-      egHtml: `claim · explanation · example · transition — on repeat.`,
-      fix: "vary openings, lengths, and landing points."
-    },
-    {
-      group: "structural",
-      title: "heading plus restatement",
-      egHtml: `<code>performance</code> → <em>performance matters.</em>`,
-      fix: "let the heading do its job."
-    },
-    {
-      group: "structural",
-      title: "list inflation",
-      egHtml: `<code>5 ways ai is changing x</code>, each bullet says almost nothing.`,
-      fix: "cut to the few points that actually matter."
-    },
-    {
-      group: "voice",
-      title: "false agency",
-      egHtml: `<code>the data tells us</code> · <code>the market decided</code>`,
-      fix: "name the human actor when the actor matters."
-    },
-    {
-      group: "voice",
-      title: "vague attribution",
-      egHtml: `<code>experts believe</code> · <code>research shows</code> · <code>industry observers note</code>`,
-      fix: "cite the source or cut the claim."
-    },
-    {
-      group: "voice",
-      title: "significance inflation",
-      egHtml: `<code>a pivotal moment in the evolution of</code> · <code>a testament to</code>`,
-      fix: "describe what happened and stop."
-    },
-    {
-      group: "voice",
-      title: "promotional description",
-      egHtml: `<code>vibrant hub</code> · <code>thriving ecosystem</code> · <code>nestled in</code>`,
-      fix: "describe the thing plainly."
-    },
-    {
-      group: "voice",
-      title: "emotional flatline",
-      egHtml: `<code>what surprised me most was</code> · <code>i was fascinated to discover</code>`,
-      fix: "let the content create the feeling."
-    }
-  ];
+  function expandWordEntries(entries) {
+    return entries.flatMap(([label, fix]) => (
+      label.split(/\s*\/\s*/).map(part => [part.trim(), fix])
+    ));
+  }
 
   const EXAMPLES = [
     {
@@ -324,34 +177,32 @@
   const esc = s => s.replace(/[&<>"']/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
 
   // build lookup
-  const t1 = new Map(TIER_1.map(([w, f]) => [w.toLowerCase(), f]));
-  const t2 = new Map(TIER_2.map(([w, f]) => [w.toLowerCase(), f]));
+  const t1 = new Map(expandWordEntries(TIER_1).map(([w, f]) => [w.toLowerCase(), f]));
+  const t2 = new Map(expandWordEntries(TIER_2).map(([w, f]) => [w.toLowerCase(), f]));
   const t3 = new Set(TIER_3.map(w => w.toLowerCase()));
 
-  // phrase-style patterns (multi-word regex forms)
+  function escapeRegex(value) {
+    return value.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+  }
+
+  function buildFillerRegexes() {
+    return FILLERS.map(label => {
+      const lower = label.toLowerCase();
+      if (lower === "in today's [x]") {
+        return { re: /\bin today'?s [\w-]+(?:\s[\w-]+)?\b/gi, label };
+      }
+      if (lower === "let me know if...") {
+        return { re: /\blet me know if\b/gi, label };
+      }
+      const source = `\\b${escapeRegex(lower).replace(/\s+/g, "\\s+")}\\b`;
+      return { re: new RegExp(source, "gi"), label };
+    });
+  }
+
+  // heuristics that are realistic to catch in-browser
   const PATTERN_REGEXES = [
-    { re: /\bnot (?:a )?[\w'-]+[,\.] (?:it'?s )?(?:a |but )[\w'-]+/gi, label: "binary contrast" },
-    { re: /\b(?:so why|but what|but how) (?:does|do|is|are) this/gi, label: "rhetorical transition" },
-    { re: /\blet's dive in(?:to)?\b/gi, label: "signposting" },
-    { re: /\bhere'?s what you need to know\b/gi, label: "signposting" },
-    { re: /\blet me think step by step\b/gi, label: "reasoning leakage" },
-    { re: /\b(?:the data|the market|the product|the complaint) (?:tells us|decided|became|knows)\b/gi, label: "false agency" },
-    { re: /\b(?:experts (?:believe|say)|research shows|industry observers note|studies show)\b/gi, label: "vague attribution" },
-    { re: /\b(?:vibrant|thriving|bustling) (?:hub|ecosystem|community)\b/gi, label: "promotional" },
-    { re: /\bwhat surprised me most was\b/gi, label: "emotional flatline" },
-    { re: /\bat the end of the day\b/gi, label: "filler" },
-    { re: /\bin today'?s [\w-]+(?:\s[\w-]+)?\b/gi, label: "filler opener" },
-    { re: /\bthe future looks bright\b/gi, label: "generic close" },
-    { re: /\bas we move forward\b/gi, label: "generic close" },
-    { re: /\bin conclusion\b/gi, label: "generic close" },
-    { re: /\bin summary\b/gi, label: "generic close" },
-    { re: /\bhere'?s the thing\b/gi, label: "throat-clearing" },
-    { re: /\bit turns out\b/gi, label: "filler" },
-    { re: /\bit'?s worth noting\b/gi, label: "filler" },
-    { re: /\blet that sink in\b/gi, label: "emphasis crutch" },
-    { re: /\bi hope this helps\b/gi, label: "chatbot artifact" },
-    { re: /\bgreat question[!\.]?/gi, label: "chatbot artifact" },
-    { re: /\b(?:certainly|absolutely|of course)[,!]/gi, label: "chatbot opener" }
+    ...DETECTOR_PATTERNS,
+    ...buildFillerRegexes()
   ];
 
   // tier-1 entries that are phrases, detected as regex
@@ -466,7 +317,7 @@
     const { flags, tierCounts, words } = res;
     const density = words ? flags / words : 0;
     if (flags === 0) {
-      return `<span class="score-clean">clean on this pass.</span>&nbsp;the demo did not catch anything in its subset. still read it yourself.`;
+      return `<span class="score-clean">clean on this pass.</span>&nbsp;the demo did not catch anything in the browser pass. still read it yourself.`;
     }
     const bits = [];
     if (tierCounts.t1) bits.push(`${tierCounts.t1} tier-1 word${tierCounts.t1 > 1 ? "s" : ""}`);
@@ -476,7 +327,7 @@
     const severity = density > 0.06 || tierCounts.pat >= 3 || tierCounts.t1 >= 4
       ? `<span class="score-strong">clear ai smell.</span>`
       : `<span class="score-neutral">mixed.</span>`;
-    return `${severity}&nbsp;${bits.join(" · ")} in the demo subset. full review still recommended.`;
+    return `${severity}&nbsp;${bits.join(" · ")} in the browser pass. full review still recommended.`;
   }
 
   function updateDetector() {
@@ -578,6 +429,10 @@
   const patHost = document.querySelector("[data-patterns]");
   if (patHost) {
     PATTERNS.forEach(p => {
+      const examplesHtml = (p.examples || []).length
+        ? `<p class="eg">${p.examples.map(example => `<code>${esc(example)}</code>`).join(" · ")}</p>`
+        : "";
+      const fixHtml = p.fix ? `<p class="fix-line"><b>fix</b>${esc(p.fix)}</p>` : "";
       const el = document.createElement("article");
       el.className = "pat";
       el.innerHTML = `
@@ -585,8 +440,8 @@
           <h3>${esc(p.title)}</h3>
           <span class="pat-group">${esc(p.group)}</span>
         </header>
-        <p class="eg">${p.egHtml}</p>
-        <p class="fix-line"><b>fix</b>${esc(p.fix)}</p>
+        ${examplesHtml}
+        ${fixHtml}
       `;
       patHost.appendChild(el);
     });

--- a/docs/app.js
+++ b/docs/app.js
@@ -1,0 +1,623 @@
+/* =====================================================
+   stop slop — app.js
+   powers: theme toggle, hero demo cycle, live detector,
+           examples renderer, tier/pattern renderers,
+           install tabs, copy buttons
+   ===================================================== */
+
+(() => {
+  // ---------- data pulled from references (verbatim entries) ----------
+
+  const TIER_1 = [
+    ["delve", "explore"], ["delve into", "look at"],
+    ["utilize", "use"],
+    ["robust", "strong"],
+    ["comprehensive", "complete"],
+    ["pivotal", "important"],
+    ["transformative", "describe what changed"],
+    ["landscape", "field"],
+    ["tapestry", "name the complexity"],
+    ["paradigm", "model"],
+    ["embark", "start"],
+    ["beacon", "rewrite"],
+    ["testament to", "shows"],
+    ["seamless", "smooth"],
+    ["impactful", "effective"],
+    ["actionable", "concrete"],
+    ["thought leader", "expert"],
+    ["best practices", "what works"],
+    ["in order to", "to"],
+    ["due to the fact that", "because"],
+    ["serves as", "is"],
+    ["boasts", "has"],
+    ["commence", "start"],
+    ["ascertain", "find out"],
+    ["endeavor", "effort"],
+    ["deep dive", "look at"],
+    ["unpack", "explain"],
+    ["ever-evolving", "changing"],
+    ["watershed moment", "turning point"],
+    ["at its core", "cut it"]
+  ];
+
+  const TIER_2 = [
+    ["harness", "use"],
+    ["navigate", "handle"],
+    ["elevate", "improve"],
+    ["empower", "enable"],
+    ["streamline", "simplify"],
+    ["bolster", "strengthen"],
+    ["spearhead", "lead"],
+    ["resonate", "connect"],
+    ["ecosystem", "network"],
+    ["myriad", "many"],
+    ["plethora", "many"],
+    ["encompass", "include"],
+    ["catalyze", "trigger"],
+    ["cultivate", "build"],
+    ["illuminate", "clarify"],
+    ["cornerstone", "foundation"],
+    ["paramount", "most important"],
+    ["poised", "ready"],
+    ["nascent", "early"],
+    ["overarching", "broad"],
+    ["augment", "add to"]
+  ];
+
+  const TIER_3 = [
+    "significant", "effective", "dynamic", "scalable", "compelling",
+    "valuable", "key", "vital", "remarkable", "sophisticated"
+  ];
+
+  const OPENERS = [
+    "Certainly,", "Absolutely,", "Of course,", "Great question,",
+    "Moreover,", "Furthermore,", "Additionally,", "Importantly,", "Interestingly,"
+  ];
+
+  const FILLERS = [
+    "Here's the thing", "It turns out", "The truth is", "Let me be clear",
+    "It's worth noting", "At the end of the day", "When it comes to",
+    "In today's", "The future looks bright", "Only time will tell",
+    "As we move forward", "I hope this helps", "Let me know if",
+    "Without further ado", "In conclusion", "In summary"
+  ];
+
+  const PATTERNS = [
+    {
+      group: "sentence",
+      title: "binary contrast",
+      egHtml: `<code>not x, but y</code> · <code>the real issue is not x. it's y.</code>`,
+      fix: "state y directly."
+    },
+    {
+      group: "sentence",
+      title: "negative listing",
+      egHtml: `<code>not a tool. not a workflow. a mindset.</code>`,
+      fix: "say the actual point without the runway."
+    },
+    {
+      group: "sentence",
+      title: "rhetorical question transition",
+      egHtml: `<code>so why does this matter?</code> · <code>but what does this mean for teams?</code>`,
+      fix: "if you know the answer, say it."
+    },
+    {
+      group: "sentence",
+      title: "signposting",
+      egHtml: `<code>let's dive in</code> · <code>in this section</code> · <code>here's what you need to know</code>`,
+      fix: "cut the announcement and start with the point."
+    },
+    {
+      group: "sentence",
+      title: "reasoning-chain leakage",
+      egHtml: `<code>let me think step by step</code> · <code>working through this logically</code>`,
+      fix: "give the conclusion, then the reasoning."
+    },
+    {
+      group: "structural",
+      title: "rule of three everywhere",
+      egHtml: `too many triads make writing feel generated.`,
+      fix: "use one, two, or four when that fits better."
+    },
+    {
+      group: "structural",
+      title: "uniform sentence length",
+      egHtml: `three even sentences in a row is one of the clearest ai signals.`,
+      fix: "vary rhythm on purpose."
+    },
+    {
+      group: "structural",
+      title: "uniform paragraph shape",
+      egHtml: `claim · explanation · example · transition — on repeat.`,
+      fix: "vary openings, lengths, and landing points."
+    },
+    {
+      group: "structural",
+      title: "heading plus restatement",
+      egHtml: `<code>performance</code> → <em>performance matters.</em>`,
+      fix: "let the heading do its job."
+    },
+    {
+      group: "structural",
+      title: "list inflation",
+      egHtml: `<code>5 ways ai is changing x</code>, each bullet says almost nothing.`,
+      fix: "cut to the few points that actually matter."
+    },
+    {
+      group: "voice",
+      title: "false agency",
+      egHtml: `<code>the data tells us</code> · <code>the market decided</code>`,
+      fix: "name the human actor when the actor matters."
+    },
+    {
+      group: "voice",
+      title: "vague attribution",
+      egHtml: `<code>experts believe</code> · <code>research shows</code> · <code>industry observers note</code>`,
+      fix: "cite the source or cut the claim."
+    },
+    {
+      group: "voice",
+      title: "significance inflation",
+      egHtml: `<code>a pivotal moment in the evolution of</code> · <code>a testament to</code>`,
+      fix: "describe what happened and stop."
+    },
+    {
+      group: "voice",
+      title: "promotional description",
+      egHtml: `<code>vibrant hub</code> · <code>thriving ecosystem</code> · <code>nestled in</code>`,
+      fix: "describe the thing plainly."
+    },
+    {
+      group: "voice",
+      title: "emotional flatline",
+      egHtml: `<code>what surprised me most was</code> · <code>i was fascinated to discover</code>`,
+      fix: "let the content create the feeling."
+    }
+  ];
+
+  const EXAMPLES = [
+    {
+      beforeHtml: `<mark>Here's the thing:</mark> building products is hard. <del>Not because the tech is hard. Because people are hard.</del> <del>Let that sink in.</del>`,
+      afterText: "Building products is hard. The tech is manageable. People are not.",
+      changes: ["removed throat-clearing", "removed contrast template", "removed emphasis crutch"]
+    },
+    {
+      beforeHtml: `<del>In today's fast-moving landscape,</del> teams need to <del>leverage robust</del> workflows <del>in order to navigate</del> complexity.`,
+      afterText: "Teams need workflows that hold up under pressure.",
+      changes: ["cut stacked buzzwords", "removed filler", "replaced abstract phrasing with a direct claim"]
+    },
+    {
+      beforeHtml: `<del>Great question!</del> This platform <del>serves as a comprehensive</del> hub for modern collaboration. <del>I hope this helps.</del>`,
+      afterText: "This platform brings docs, chat, and task tracking into one place.",
+      changes: ["removed chatbot artifacts", "replaced inflated verbs", "named actual product behavior"]
+    },
+    {
+      beforeHtml: `<del>Industry observers note that</del> adoption has accelerated, <del>showcasing the transformative potential of</del> the product.`,
+      afterText: "Usage doubled over six months after the team cut setup time from two days to twenty minutes.",
+      changes: ["replaced vague attribution with a concrete claim", "cut significance inflation", "replaced abstract praise with a measurable outcome"]
+    },
+    {
+      beforeHtml: `<del>Let's dive into five reasons this matters:</del><br>1. speed · 2. quality · 3. innovation · 4. alignment · 5. growth`,
+      afterText: "This matters for two reasons. It cuts review time, and it reduces the number of decisions teams have to revisit later.",
+      changes: ["removed signposting", "cut inflated list", "kept only points that carried real meaning"]
+    },
+    {
+      beforeHtml: `<del>The future looks bright as we move forward into this new era of possibility.</del>`,
+      afterText: "The next milestone is simple: ship the rollout, measure retention, and see if users come back without prompting.",
+      changes: ["removed generic conclusion", "replaced mood with an actual next step"]
+    }
+  ];
+
+  // compact set for hero demo (3 of the best)
+  const HERO_DEMO = [
+    {
+      beforeHtml: `<span class="highlight">In today's fast-moving landscape,</span> teams <span class="strike">need to leverage robust</span> workflows <span class="strike">in order to navigate</span> complexity.`,
+      afterHtml: `<span class="kept">Teams need workflows that hold up under pressure.</span>`,
+      changes: ["landscape", "leverage", "robust", "in order to", "navigate"]
+    },
+    {
+      beforeHtml: `<span class="strike">Great question!</span> This platform <span class="strike">serves as a comprehensive</span> hub for modern collaboration. <span class="strike">I hope this helps.</span>`,
+      afterHtml: `<span class="kept">This platform brings docs, chat, and task tracking into one place.</span>`,
+      changes: ["chatbot opener", "serves as", "comprehensive", "filler close"]
+    },
+    {
+      beforeHtml: `<span class="highlight">Here's the thing:</span> building products is hard. <span class="strike">Not because the tech is hard. Because people are hard.</span> <span class="strike">Let that sink in.</span>`,
+      afterHtml: `<span class="kept">Building products is hard. The tech is manageable. People are not.</span>`,
+      changes: ["throat-clearing", "not x, but y", "emphasis crutch"]
+    },
+    {
+      beforeHtml: `<span class="strike">Industry observers note that</span> adoption has accelerated, <span class="strike">showcasing the transformative potential of</span> the product.`,
+      afterHtml: `<span class="kept">Usage doubled over six months after the team cut setup time from two days to twenty minutes.</span>`,
+      changes: ["vague attribution", "significance inflation", "abstract praise"]
+    },
+    {
+      beforeHtml: `<span class="highlight">Let's dive into</span> five reasons this matters: <span class="strike">speed, quality, innovation, alignment, growth.</span>`,
+      afterHtml: `<span class="kept">This matters for two reasons. It cuts review time, and it reduces decisions teams revisit later.</span>`,
+      changes: ["let's dive in", "list inflation"]
+    },
+    {
+      beforeHtml: `<span class="strike">The future looks bright as we move forward into this new era of possibility.</span>`,
+      afterHtml: `<span class="kept">The next milestone is simple: ship the rollout, measure retention, and see if users come back without prompting.</span>`,
+      changes: ["generic ending", "mood over substance"]
+    }
+  ];
+
+  // ---------- theme toggle ----------
+
+  const root = document.documentElement;
+  const saved = localStorage.getItem("slop-theme");
+  if (saved) root.setAttribute("data-theme", saved);
+  else if (matchMedia("(prefers-color-scheme: dark)").matches) root.setAttribute("data-theme", "dark");
+
+  document.querySelector("[data-theme-toggle]")?.addEventListener("click", () => {
+    const current = root.getAttribute("data-theme") === "dark" ? "dark" : "light";
+    const next = current === "dark" ? "light" : "dark";
+    root.setAttribute("data-theme", next);
+    localStorage.setItem("slop-theme", next);
+  });
+
+  // ---------- hero demo cycle ----------
+
+  const heroBefore = document.querySelector("[data-demo-before]");
+  const heroAfter = document.querySelector("[data-demo-after]");
+  const heroChanges = document.querySelector("[data-demo-changes]");
+  const heroIndex = document.querySelector("[data-demo-index]");
+  const heroTotal = document.querySelector("[data-demo-total]");
+  const heroNext = document.querySelector("[data-demo-next]");
+  let heroI = 0;
+  let heroTimer = null;
+
+  function renderHero(i) {
+    const d = HERO_DEMO[i];
+    if (!d) return;
+    heroBefore.classList.remove("fadein");
+    heroAfter.classList.remove("fadein");
+    heroChanges.innerHTML = "";
+    heroBefore.innerHTML = d.beforeHtml;
+    heroAfter.innerHTML = d.afterHtml;
+    d.changes.forEach(c => {
+      const li = document.createElement("li");
+      li.textContent = c;
+      heroChanges.appendChild(li);
+    });
+    if (heroIndex) heroIndex.textContent = String(i + 1);
+    // trigger a micro-animation
+    requestAnimationFrame(() => {
+      heroBefore.classList.add("fadein");
+      heroAfter.classList.add("fadein");
+    });
+  }
+
+  function cycleHero() {
+    heroI = (heroI + 1) % HERO_DEMO.length;
+    renderHero(heroI);
+  }
+
+  if (heroBefore) {
+    heroTotal.textContent = String(HERO_DEMO.length);
+    renderHero(0);
+    heroTimer = setInterval(cycleHero, 4800);
+    heroNext?.addEventListener("click", () => {
+      clearInterval(heroTimer);
+      cycleHero();
+      heroTimer = setInterval(cycleHero, 4800);
+    });
+  }
+
+  // add small fade-in style dynamically
+  const s = document.createElement("style");
+  s.textContent = `
+    [data-demo-before], [data-demo-after] { transition: opacity .35s ease, transform .35s ease; opacity: .2; transform: translateY(4px); }
+    [data-demo-before].fadein, [data-demo-after].fadein { opacity: 1; transform: none; }
+  `;
+  document.head.appendChild(s);
+
+  // ---------- detector ----------
+
+  const detInput = document.getElementById("det-input");
+  const detOutput = document.querySelector("[data-det-output]");
+  const detFlags = document.querySelector("[data-det-flags]");
+  const detWords = document.querySelector("[data-det-words]");
+  const detScore = document.querySelector("[data-det-score]");
+
+  // escape html
+  const esc = s => s.replace(/[&<>"']/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+
+  // build lookup
+  const t1 = new Map(TIER_1.map(([w, f]) => [w.toLowerCase(), f]));
+  const t2 = new Map(TIER_2.map(([w, f]) => [w.toLowerCase(), f]));
+  const t3 = new Set(TIER_3.map(w => w.toLowerCase()));
+
+  // phrase-style patterns (multi-word regex forms)
+  const PATTERN_REGEXES = [
+    { re: /\bnot (?:a )?[\w'-]+[,\.] (?:it'?s )?(?:a |but )[\w'-]+/gi, label: "binary contrast" },
+    { re: /\b(?:so why|but what|but how) (?:does|do|is|are) this/gi, label: "rhetorical transition" },
+    { re: /\blet's dive in(?:to)?\b/gi, label: "signposting" },
+    { re: /\bhere'?s what you need to know\b/gi, label: "signposting" },
+    { re: /\blet me think step by step\b/gi, label: "reasoning leakage" },
+    { re: /\b(?:the data|the market|the product|the complaint) (?:tells us|decided|became|knows)\b/gi, label: "false agency" },
+    { re: /\b(?:experts (?:believe|say)|research shows|industry observers note|studies show)\b/gi, label: "vague attribution" },
+    { re: /\b(?:vibrant|thriving|bustling) (?:hub|ecosystem|community)\b/gi, label: "promotional" },
+    { re: /\bwhat surprised me most was\b/gi, label: "emotional flatline" },
+    { re: /\bat the end of the day\b/gi, label: "filler" },
+    { re: /\bin today'?s [\w-]+(?:\s[\w-]+)?\b/gi, label: "filler opener" },
+    { re: /\bthe future looks bright\b/gi, label: "generic close" },
+    { re: /\bas we move forward\b/gi, label: "generic close" },
+    { re: /\bin conclusion\b/gi, label: "generic close" },
+    { re: /\bin summary\b/gi, label: "generic close" },
+    { re: /\bhere'?s the thing\b/gi, label: "throat-clearing" },
+    { re: /\bit turns out\b/gi, label: "filler" },
+    { re: /\bit'?s worth noting\b/gi, label: "filler" },
+    { re: /\blet that sink in\b/gi, label: "emphasis crutch" },
+    { re: /\bi hope this helps\b/gi, label: "chatbot artifact" },
+    { re: /\bgreat question[!\.]?/gi, label: "chatbot artifact" },
+    { re: /\b(?:certainly|absolutely|of course)[,!]/gi, label: "chatbot opener" }
+  ];
+
+  // tier-1 entries that are phrases, detected as regex
+  const PHRASE_REGEXES = [
+    ...[...t1.keys()].filter(k => k.includes(" ")).map(k => ({
+      re: new RegExp("\\b" + k.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&") + "\\b", "gi"),
+      tier: 1,
+      fix: t1.get(k)
+    })),
+    ...[...t2.keys()].filter(k => k.includes(" ")).map(k => ({
+      re: new RegExp("\\b" + k.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&") + "\\b", "gi"),
+      tier: 2,
+      fix: t2.get(k)
+    }))
+  ];
+
+  function detect(text) {
+    if (!text) return { html: `<span style="color:var(--ink-mute); font-style: italic;">paste prose on the left and see it flagged here…</span>`, flags: 0, tierCounts: { t1: 0, t2: 0, t3: 0, pat: 0 }, total: 0, words: 0 };
+
+    // collect all spans: [start, end, type, title]
+    const spans = [];
+
+    // patterns (regex) first — higher priority
+    PATTERN_REGEXES.forEach(({ re, label }) => {
+      re.lastIndex = 0;
+      let m;
+      while ((m = re.exec(text))) {
+        spans.push({ start: m.index, end: m.index + m[0].length, type: "pat", title: label });
+      }
+    });
+
+    // phrase tier words
+    PHRASE_REGEXES.forEach(({ re, tier, fix }) => {
+      re.lastIndex = 0;
+      let m;
+      while ((m = re.exec(text))) {
+        spans.push({ start: m.index, end: m.index + m[0].length, type: tier === 1 ? "t1" : "t2", title: `${m[0]} → ${fix}` });
+      }
+    });
+
+    // opener-at-start-of-sentence
+    OPENERS.forEach(op => {
+      const re = new RegExp("(?:^|[\\.\\?!\\n]\\s+)(" + op.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&") + ")", "g");
+      let m;
+      while ((m = re.exec(text))) {
+        const start = m.index + m[0].length - m[1].length;
+        spans.push({ start, end: start + m[1].length, type: "open", title: "bad opener" });
+      }
+    });
+
+    // word-level tier tokens (single-word entries)
+    const tokenRe = /[A-Za-z][A-Za-z'-]*/g;
+    let tm;
+    while ((tm = tokenRe.exec(text))) {
+      const word = tm[0];
+      const lc = word.toLowerCase();
+      if (t1.has(lc) && !lc.includes(" ")) {
+        spans.push({ start: tm.index, end: tm.index + word.length, type: "t1", title: `${word} → ${t1.get(lc)}` });
+      } else if (t2.has(lc) && !lc.includes(" ")) {
+        spans.push({ start: tm.index, end: tm.index + word.length, type: "t2", title: `${word} → ${t2.get(lc)}` });
+      } else if (t3.has(lc)) {
+        spans.push({ start: tm.index, end: tm.index + word.length, type: "t3", title: `${word} — flag at density` });
+      }
+    }
+
+    // merge/dedupe overlapping spans, keep higher priority (pat > t1 > t2 > open > t3)
+    const prio = { pat: 5, t1: 4, t2: 3, open: 2, t3: 1 };
+    spans.sort((a, b) => a.start - b.start || b.end - b.start - (a.end - a.start));
+    const merged = [];
+    for (const sp of spans) {
+      const last = merged[merged.length - 1];
+      if (last && sp.start < last.end) {
+        // overlap — prefer higher-priority type; keep wider span
+        if (prio[sp.type] > prio[last.type]) {
+          merged[merged.length - 1] = {
+            start: Math.min(last.start, sp.start),
+            end: Math.max(last.end, sp.end),
+            type: sp.type,
+            title: sp.title
+          };
+        } else {
+          last.end = Math.max(last.end, sp.end);
+        }
+      } else {
+        merged.push({ ...sp });
+      }
+    }
+
+    // build html with wrapping
+    let out = "";
+    let cursor = 0;
+    const counts = { t1: 0, t2: 0, t3: 0, pat: 0, open: 0 };
+    for (const sp of merged) {
+      if (sp.start > cursor) out += esc(text.slice(cursor, sp.start));
+      const slice = text.slice(sp.start, sp.end);
+      counts[sp.type] = (counts[sp.type] || 0) + 1;
+      out += `<span class="hl hl-${sp.type}" title="${esc(sp.title || "")}">${esc(slice)}</span>`;
+      cursor = sp.end;
+    }
+    if (cursor < text.length) out += esc(text.slice(cursor));
+    out = out.replace(/\n/g, "<br>");
+
+    return {
+      html: out,
+      flags: merged.length,
+      tierCounts: counts,
+      words: (text.match(/\b[\w'-]+\b/g) || []).length
+    };
+  }
+
+  function verdict(res) {
+    const { flags, tierCounts, words } = res;
+    const density = words ? flags / words : 0;
+    if (flags === 0) {
+      return `<span class="score-clean">clean.</span>&nbsp;no common ai patterns caught. worth a human read anyway.`;
+    }
+    const bits = [];
+    if (tierCounts.t1) bits.push(`${tierCounts.t1} tier-1 word${tierCounts.t1 > 1 ? "s" : ""}`);
+    if (tierCounts.t2) bits.push(`${tierCounts.t2} tier-2 word${tierCounts.t2 > 1 ? "s" : ""}`);
+    if (tierCounts.pat) bits.push(`${tierCounts.pat} pattern${tierCounts.pat > 1 ? "s" : ""}`);
+    if (tierCounts.open) bits.push(`${tierCounts.open} opener${tierCounts.open > 1 ? "s" : ""}`);
+    const severity = density > 0.06 || tierCounts.pat >= 3 || tierCounts.t1 >= 4
+      ? `<span class="score-strong">clear ai smell.</span>`
+      : `<span class="score-neutral">mixed.</span>`;
+    return `${severity}&nbsp;${bits.join(" · ")}. rewrite recommended.`;
+  }
+
+  function updateDetector() {
+    if (!detInput) return;
+    const res = detect(detInput.value);
+    detOutput.innerHTML = res.html;
+    detFlags.textContent = res.flags;
+    detWords.textContent = res.words;
+    detScore.innerHTML = verdict(res);
+  }
+
+  if (detInput) {
+    let tid = null;
+    detInput.addEventListener("input", () => {
+      clearTimeout(tid);
+      tid = setTimeout(updateDetector, 80);
+    });
+    updateDetector();
+  }
+
+  const defaultDraft = detInput ? detInput.value : "";
+  document.querySelector("[data-det-reset]")?.addEventListener("click", () => {
+    if (!detInput) return;
+    detInput.value = defaultDraft;
+    updateDetector();
+    detInput.focus();
+  });
+  document.querySelector("[data-det-clear]")?.addEventListener("click", () => {
+    if (!detInput) return;
+    detInput.value = "";
+    updateDetector();
+    detInput.focus();
+  });
+
+  // ---------- examples renderer ----------
+
+  const exList = document.querySelector("[data-examples-list]");
+  if (exList) {
+    EXAMPLES.forEach(ex => {
+      const li = document.createElement("li");
+      li.className = "ex";
+      li.innerHTML = `
+        <div class="ex-before">
+          <span class="ex-side-label">before</span>
+          ${ex.beforeHtml}
+        </div>
+        <div class="ex-after">
+          <span class="ex-side-label">after</span>
+          ${esc(ex.afterText)}
+        </div>
+        <ul class="ex-changes">
+          ${ex.changes.map(c => `<li>${esc(c)}</li>`).join("")}
+        </ul>
+      `;
+      exList.appendChild(li);
+    });
+  }
+
+  // ---------- tier pills ----------
+
+  function tierNode(w, fix) {
+    const n = document.createElement("span");
+    n.className = "wpill";
+    n.innerHTML = `${esc(w)} <span class="arrow">→</span> <span class="fix">${esc(fix)}</span>`;
+    return n;
+  }
+
+  const t1Host = document.querySelector('[data-tier="1"]');
+  const t2Host = document.querySelector('[data-tier="2"]');
+  const t3Host = document.querySelector('[data-tier="3"]');
+
+  TIER_1.forEach(([w, f]) => t1Host?.appendChild(tierNode(w, f)));
+  TIER_2.forEach(([w, f]) => t2Host?.appendChild(tierNode(w, f)));
+  TIER_3.forEach(w => {
+    const n = document.createElement("span");
+    n.className = "wpill";
+    n.textContent = w;
+    t3Host?.appendChild(n);
+  });
+
+  // openers / fillers
+  const openHost = document.querySelector("[data-openers]");
+  const fillHost = document.querySelector("[data-fillers]");
+  OPENERS.forEach(o => {
+    const n = document.createElement("span");
+    n.className = "ofpill";
+    n.textContent = o;
+    openHost?.appendChild(n);
+  });
+  FILLERS.forEach(f => {
+    const n = document.createElement("span");
+    n.className = "ofpill";
+    n.textContent = f;
+    fillHost?.appendChild(n);
+  });
+
+  // ---------- patterns renderer ----------
+
+  const patHost = document.querySelector("[data-patterns]");
+  if (patHost) {
+    PATTERNS.forEach(p => {
+      const el = document.createElement("article");
+      el.className = "pat";
+      el.innerHTML = `
+        <header>
+          <h3>${esc(p.title)}</h3>
+          <span class="pat-group">${esc(p.group)}</span>
+        </header>
+        <p class="eg">${p.egHtml}</p>
+        <p class="fix-line"><b>fix</b>${esc(p.fix)}</p>
+      `;
+      patHost.appendChild(el);
+    });
+  }
+
+  // ---------- install tabs ----------
+
+  document.querySelectorAll("[data-inst-tab]").forEach(btn => {
+    btn.addEventListener("click", () => {
+      const key = btn.dataset.instTab;
+      document.querySelectorAll("[data-inst-tab]").forEach(b => b.classList.toggle("active", b === btn));
+      document.querySelectorAll("[data-inst-pane]").forEach(p => p.classList.toggle("active", p.dataset.instPane === key));
+    });
+  });
+
+  // ---------- copy buttons ----------
+
+  document.querySelectorAll("[data-copy]").forEach(btn => {
+    btn.addEventListener("click", async () => {
+      const pane = btn.closest(".inst-pane");
+      const codeEl = pane?.querySelector("pre code");
+      if (!codeEl) return;
+      const text = codeEl.innerText;
+      try {
+        await navigator.clipboard.writeText(text);
+        const orig = btn.textContent;
+        btn.textContent = "copied";
+        btn.classList.add("copied");
+        setTimeout(() => { btn.textContent = orig; btn.classList.remove("copied"); }, 1400);
+      } catch (_) {}
+    });
+  });
+
+})();

--- a/docs/index.html
+++ b/docs/index.html
@@ -111,7 +111,7 @@
     <div class="sec-head">
       <span class="sec-num">§ 01</span>
       <h2 id="what-title" class="sec-title">what it does.</h2>
-      <p class="sec-kicker">a short, opinionated editing pass — not a voice layer.</p>
+      <p class="sec-kicker">a short, opinionated editing pass. not a voice layer.</p>
     </div>
 
     <ol class="what-grid">
@@ -199,7 +199,7 @@
     <div class="sec-head">
       <span class="sec-num">§ 03</span>
       <h2 id="det-title" class="sec-title">live detector.</h2>
-      <p class="sec-kicker">paste prose on the left. the skill's word and pattern flags light up on the right.</p>
+      <p class="sec-kicker">paste prose on the left. flags appear on the right.</p>
     </div>
 
     <div class="det-stage">
@@ -244,7 +244,7 @@ In conclusion, the future looks bright as we move forward.</textarea>
     <div class="sec-head">
       <span class="sec-num">§ 04</span>
       <h2 id="ex-title" class="sec-title">before &amp; after.</h2>
-      <p class="sec-kicker">six drafts, edited plainly. each row shows what came out, what went in, and why.</p>
+      <p class="sec-kicker">six drafts, plainly edited. each card shows the cut, the replacement, and the reason.</p>
     </div>
 
     <ol class="ex-list" data-examples-list></ol>

--- a/docs/index.html
+++ b/docs/index.html
@@ -233,7 +233,7 @@ In conclusion, the future looks bright as we move forward.</textarea>
           <li><span class="sw sw-open"></span> bad opener</li>
         </ul>
         <div class="det-score" data-det-score></div>
-        <p class="modes-note">this demo checks a curated subset of the rules. <code>SKILL.md</code> and the files under <code>references/</code> stay the source of truth.</p>
+        <p class="modes-note">this demo loads the canonical word lists and pattern cards from the repo. structural detection is still limited to browser-detectable heuristics.</p>
       </div>
     </div>
   </div>
@@ -441,10 +441,17 @@ use stop slop on this memo</code></pre>
       <header>repo contents</header>
 <pre><code>stop-slop-refined/
 ├── SKILL.md
+├── docs/
+│   ├── site-data.js
+│   ├── index.html
+│   ├── app.js
+│   └── styles.css
 ├── references/
 │   ├── words.md
 │   ├── patterns.md
 │   └── examples.md
+├── scripts/
+│   └── generate-site-data.mjs
 ├── ATTRIBUTION.md
 ├── LICENSE
 └── README.md</code></pre>
@@ -521,6 +528,7 @@ use stop slop on this memo</code></pre>
   </div>
 </footer>
 
+<script src="site-data.js"></script>
 <script src="app.js"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,525 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
+<meta name="color-scheme" content="light dark" />
+<title>stop slop — a public writing skill</title>
+<meta name="description" content="A public writing skill for removing common AI patterns from prose. Audit drafts, rewrite content, pressure-test writing." />
+<meta property="og:title" content="stop slop" />
+<meta property="og:description" content="A public writing skill for removing common AI patterns from prose." />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,800;0,9..144,900;1,9..144,300;1,9..144,400;1,9..144,600;1,9..144,800;1,9..144,900&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap">
+<link rel="stylesheet" href="styles.css">
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext x='8' y='78' font-family='Georgia,serif' font-size='96' font-style='italic' font-weight='900' fill='%23141211'%3Es%3C/text%3E%3Cpath d='M6 58 L64 58' stroke='%23c83a26' stroke-width='10' stroke-linecap='round' transform='rotate(-6 35 58)'/%3E%3C/svg%3E">
+</head>
+<body>
+
+<!-- MASTHEAD -->
+<header class="masthead">
+  <div class="wrap">
+    <a class="wordmark" href="#top" aria-label="stop slop">
+      <span class="wm-stop">stop</span><span class="wm-sep">/</span><span class="wm-slop">slop</span><span class="wm-dot">.</span>
+    </a>
+    <nav class="nav" aria-label="sections">
+      <a href="#what">what</a>
+      <a href="#demo">demo</a>
+      <a href="#examples">examples</a>
+      <a href="#words">words</a>
+      <a href="#patterns">patterns</a>
+      <a href="#install">install</a>
+    </nav>
+    <div class="mast-right">
+      <button class="theme" type="button" data-theme-toggle aria-label="toggle theme" title="toggle theme">
+        <span class="t-light" aria-hidden="true">☼</span>
+        <span class="t-dark" aria-hidden="true">☾</span>
+      </button>
+      <a class="gh" href="https://github.com/welttowelt/stop-slop-refined" target="_blank" rel="noopener">
+        github <span aria-hidden="true">→</span>
+      </a>
+    </div>
+  </div>
+</header>
+
+<main id="top">
+
+<!-- HERO -->
+<section class="hero" aria-labelledby="hero-title">
+  <div class="wrap hero-wrap">
+
+    <aside class="hero-meta">
+      <span class="tag tag-live"><span class="dot"></span> public release</span>
+      <span class="tag">mit license</span>
+      <span class="tag">claude · codex · chatgpt</span>
+    </aside>
+
+    <h1 id="hero-title" class="display">
+      <span class="d-line">stop</span>
+      <span class="d-line slant"><em>slop</em><span class="mark"></span></span>
+      <span class="d-line small">a writing skill.</span>
+    </h1>
+
+    <div class="hero-body">
+      <p class="lede">
+        a public writing skill for removing common ai patterns from prose.
+      </p>
+      <p class="deck">
+        use it to audit drafts, rewrite content, or pressure-test writing that feels too polished,
+        too generic, or too obviously machine-generated.
+      </p>
+      <div class="cta-row">
+        <a class="btn btn-primary" href="#install">install <span aria-hidden="true">↓</span></a>
+        <a class="btn btn-ghost" href="#demo">try the detector <span aria-hidden="true">→</span></a>
+      </div>
+    </div>
+
+    <!-- hero demo: before/after reveal -->
+    <figure class="hero-demo" aria-label="live before-after demonstration">
+      <header class="demo-head">
+        <span class="d-title">before / after</span>
+        <span class="d-counter"><span data-demo-index>1</span>&nbsp;/&nbsp;<span data-demo-total>6</span></span>
+      </header>
+      <div class="demo-stage">
+        <div class="demo-side demo-before">
+          <span class="side-label">before</span>
+          <blockquote data-demo-before></blockquote>
+        </div>
+        <div class="demo-divider" aria-hidden="true">
+          <svg viewBox="0 0 24 24"><path d="M5 12h14M13 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </div>
+        <div class="demo-side demo-after">
+          <span class="side-label">after</span>
+          <blockquote data-demo-after></blockquote>
+        </div>
+      </div>
+      <footer class="demo-foot">
+        <ul class="demo-changes" data-demo-changes></ul>
+        <button class="demo-next" type="button" data-demo-next>next <span aria-hidden="true">↻</span></button>
+      </footer>
+    </figure>
+
+  </div>
+
+  <!-- subtle ruled baseline -->
+  <div class="rules" aria-hidden="true"></div>
+</section>
+
+<!-- WHAT IT DOES -->
+<section id="what" class="section what" aria-labelledby="what-title">
+  <div class="wrap">
+    <div class="sec-head">
+      <span class="sec-num">§ 01</span>
+      <h2 id="what-title" class="sec-title">what it does.</h2>
+      <p class="sec-kicker">a short, opinionated editing pass — not a voice layer.</p>
+    </div>
+
+    <ol class="what-grid">
+      <li>
+        <span class="num">01</span>
+        <h3>flags common ai writing patterns</h3>
+        <p>word-level hits, structural tells, and voice-level stance problems, all flagged separately.</p>
+      </li>
+      <li>
+        <span class="num">02</span>
+        <h3>supports two modes</h3>
+        <p><span class="pill pill-ink">rewrite</span> <span class="pill pill-out">detect</span> — default is a rewrite with a second pass; detect is flag-only.</p>
+      </li>
+      <li>
+        <span class="num">03</span>
+        <h3>splits word-level from structural</h3>
+        <p>vocabulary tiers, pattern tells, and formatting artifacts live in three separate references.</p>
+      </li>
+      <li>
+        <span class="num">04</span>
+        <h3>encourages a second pass</h3>
+        <p>one clean-up rarely fixes rhythm. the skill rewrites, then pressure-tests its own rewrite.</p>
+      </li>
+      <li>
+        <span class="num">05</span>
+        <h3>works as a local skill or a prompt pack</h3>
+        <p>drop it into claude code or codex. paste it into a chatgpt project. use it in one-off threads.</p>
+      </li>
+    </ol>
+  </div>
+</section>
+
+<!-- MODES -->
+<section id="modes" class="section modes" aria-labelledby="modes-title">
+  <div class="wrap modes-wrap">
+    <div class="sec-head">
+      <span class="sec-num">§ 02</span>
+      <h2 id="modes-title" class="sec-title">two modes.</h2>
+      <p class="sec-kicker">default is rewrite. switch to detect when you want flags without prose.</p>
+    </div>
+
+    <div class="modes-grid">
+      <article class="mode mode-rewrite">
+        <header>
+          <span class="mode-label">default</span>
+          <h3>rewrite</h3>
+        </header>
+        <ul>
+          <li><span>flag the main issues</span></li>
+          <li><span>rewrite the text</span></li>
+          <li><span>run a second pass on the rewrite</span></li>
+        </ul>
+        <footer>
+          <span class="mode-out">output</span>
+          <code>issues · rewrite · what changed · second pass</code>
+        </footer>
+      </article>
+
+      <article class="mode mode-detect">
+        <header>
+          <span class="mode-label">on request</span>
+          <h3>detect</h3>
+        </header>
+        <ul>
+          <li><span>flag only</span></li>
+          <li><span>show what reads as ai</span></li>
+          <li><span>separate clear problems from judgment calls</span></li>
+        </ul>
+        <footer>
+          <span class="mode-out">output</span>
+          <code>issues · assessment · fix direction</code>
+        </footer>
+      </article>
+    </div>
+
+    <p class="modes-note">
+      trigger detect with <span class="kbd">detect</span>, <span class="kbd">flag only</span>, <span class="kbd">audit only</span>, or <span class="kbd">scan</span>.
+    </p>
+  </div>
+</section>
+
+<!-- INTERACTIVE DETECTOR -->
+<section id="demo" class="section detector" aria-labelledby="det-title">
+  <div class="wrap">
+    <div class="sec-head">
+      <span class="sec-num">§ 03</span>
+      <h2 id="det-title" class="sec-title">live detector.</h2>
+      <p class="sec-kicker">paste prose on the left. the skill's word and pattern flags light up on the right.</p>
+    </div>
+
+    <div class="det-stage">
+      <div class="det-input-col">
+        <label class="det-label" for="det-input">your draft</label>
+        <div class="det-input-box">
+          <textarea id="det-input" spellcheck="false" autocapitalize="off" autocomplete="off">In today's fast-moving landscape, teams need to leverage robust workflows in order to navigate complexity. Let's dive in. Here's the thing: it's not just a tool. It's a paradigm.
+
+Great question! This platform serves as a comprehensive hub for modern collaboration. Industry observers note that adoption has accelerated, showcasing the transformative potential of the product.
+
+In conclusion, the future looks bright as we move forward.</textarea>
+        </div>
+        <div class="det-toolbar">
+          <button type="button" class="btn btn-ghost btn-sm" data-det-reset>reset draft</button>
+          <button type="button" class="btn btn-ghost btn-sm" data-det-clear>clear</button>
+          <span class="det-counts">
+            <span class="c-count"><b data-det-words>0</b> words</span>
+            <span class="c-count"><b data-det-flags>0</b> flags</span>
+          </span>
+        </div>
+      </div>
+
+      <div class="det-output-col">
+        <label class="det-label">flagged reading</label>
+        <div class="det-output" data-det-output aria-live="polite"></div>
+        <ul class="det-legend">
+          <li><span class="sw sw-t1"></span> tier 1 word</li>
+          <li><span class="sw sw-t2"></span> tier 2 word</li>
+          <li><span class="sw sw-t3"></span> tier 3 word</li>
+          <li><span class="sw sw-pat"></span> pattern</li>
+          <li><span class="sw sw-open"></span> bad opener</li>
+        </ul>
+        <div class="det-score" data-det-score></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- EXAMPLES -->
+<section id="examples" class="section examples" aria-labelledby="ex-title">
+  <div class="wrap">
+    <div class="sec-head">
+      <span class="sec-num">§ 04</span>
+      <h2 id="ex-title" class="sec-title">before &amp; after.</h2>
+      <p class="sec-kicker">six drafts, edited plainly. each row shows what came out, what went in, and why.</p>
+    </div>
+
+    <ol class="ex-list" data-examples-list></ol>
+  </div>
+</section>
+
+<!-- WORDS / TIERS -->
+<section id="words" class="section words" aria-labelledby="words-title">
+  <div class="wrap">
+    <div class="sec-head">
+      <span class="sec-num">§ 05</span>
+      <h2 id="words-title" class="sec-title">word flags, by tier.</h2>
+      <p class="sec-kicker">editing pressure points, not absolute bans. context still decides.</p>
+    </div>
+
+    <div class="tiers">
+      <article class="tier tier-1">
+        <header>
+          <span class="tier-tag">tier 1</span>
+          <h3>replace on sight</h3>
+          <p>unless there is a clear reason not to.</p>
+        </header>
+        <div class="tier-pills" data-tier="1"></div>
+      </article>
+      <article class="tier tier-2">
+        <header>
+          <span class="tier-tag">tier 2</span>
+          <h3>flag in clusters</h3>
+          <p>two or more in one paragraph is usually a bad sign.</p>
+        </header>
+        <div class="tier-pills" data-tier="2"></div>
+      </article>
+      <article class="tier tier-3">
+        <header>
+          <span class="tier-tag">tier 3</span>
+          <h3>flag at density</h3>
+          <p>normal words. only a problem when the draft leans on them too often.</p>
+        </header>
+        <div class="tier-pills" data-tier="3"></div>
+      </article>
+    </div>
+
+    <div class="openers-fillers">
+      <div class="of-col">
+        <h4>common bad openers</h4>
+        <div class="of-pills" data-openers></div>
+      </div>
+      <div class="of-col">
+        <h4>common filler phrases</h4>
+        <div class="of-pills" data-fillers></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- PATTERNS -->
+<section id="patterns" class="section patterns" aria-labelledby="pat-title">
+  <div class="wrap">
+    <div class="sec-head">
+      <span class="sec-num">§ 06</span>
+      <h2 id="pat-title" class="sec-title">pattern flags.</h2>
+      <p class="sec-kicker">structure and stance tells that survive clean vocabulary.</p>
+    </div>
+
+    <div class="pat-grid" data-patterns></div>
+  </div>
+</section>
+
+<!-- SEVERITY -->
+<section id="severity" class="section severity" aria-labelledby="sev-title">
+  <div class="wrap">
+    <div class="sec-head">
+      <span class="sec-num">§ 07</span>
+      <h2 id="sev-title" class="sec-title">severity.</h2>
+      <p class="sec-kicker">three bands. credibility first, then smell, then polish.</p>
+    </div>
+
+    <ol class="sev-grid">
+      <li class="sev sev-p0">
+        <header>
+          <span class="sev-label">p0</span>
+          <h3>credibility</h3>
+        </header>
+        <ul>
+          <li>fake sourcing</li>
+          <li>chatbot artifacts</li>
+          <li>cutoff disclaimers</li>
+          <li>markdown in plain-text contexts</li>
+          <li>obvious significance inflation</li>
+        </ul>
+      </li>
+      <li class="sev sev-p1">
+        <header>
+          <span class="sev-label">p1</span>
+          <h3>clear ai smell</h3>
+        </header>
+        <ul>
+          <li>tier-1 word hits</li>
+          <li>repeated templates</li>
+          <li>formulaic openings</li>
+          <li>repeated contrasts</li>
+          <li>rhythm that feels machine-even</li>
+        </ul>
+      </li>
+      <li class="sev sev-p2">
+        <header>
+          <span class="sev-label">p2</span>
+          <h3>polish</h3>
+        </header>
+        <ul>
+          <li>too many triads</li>
+          <li>too many bullets</li>
+          <li>repetitive paragraph shapes</li>
+          <li>conclusion that says nothing</li>
+        </ul>
+      </li>
+    </ol>
+
+    <div class="calib">
+      <div class="calib-col calib-strict">
+        <h4>be stricter in</h4>
+        <ul>
+          <li>essays</li>
+          <li>investor emails</li>
+          <li>public posts</li>
+          <li>website copy</li>
+        </ul>
+      </div>
+      <div class="calib-col calib-loose">
+        <h4>be looser in</h4>
+        <ul>
+          <li>docs</li>
+          <li>technical notes</li>
+          <li>fast internal chat</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- INSTALL -->
+<section id="install" class="section install" aria-labelledby="inst-title">
+  <div class="wrap">
+    <div class="sec-head">
+      <span class="sec-num">§ 08</span>
+      <h2 id="inst-title" class="sec-title">install.</h2>
+      <p class="sec-kicker">local skill, prompt pack, or paste-in. pick the one that matches where you write.</p>
+    </div>
+
+    <div class="inst-panel">
+      <div class="inst-tabs" role="tablist" aria-label="install targets">
+        <button role="tab" class="inst-tab active" data-inst-tab="claude">claude code</button>
+        <button role="tab" class="inst-tab" data-inst-tab="codex">codex</button>
+        <button role="tab" class="inst-tab" data-inst-tab="projects">chatgpt · claude projects</button>
+        <button role="tab" class="inst-tab" data-inst-tab="chat">plain chat</button>
+      </div>
+
+      <div class="inst-panes">
+        <div class="inst-pane active" data-inst-pane="claude">
+          <pre><code><span class="c-comment"># ~/.claude/skills/stop-slop</span>
+mkdir -p ~/.claude/skills
+cp -R stop-slop-public ~/.claude/skills/stop-slop</code></pre>
+          <button class="copy" type="button" data-copy>copy</button>
+        </div>
+        <div class="inst-pane" data-inst-pane="codex">
+          <pre><code><span class="c-comment"># ~/.codex/skills/stop-slop</span>
+mkdir -p ~/.codex/skills
+cp -R stop-slop-public ~/.codex/skills/stop-slop</code></pre>
+          <button class="copy" type="button" data-copy>copy</button>
+        </div>
+        <div class="inst-pane" data-inst-pane="projects">
+          <p>use <code>SKILL.md</code> as the main instruction file. pull in files under <code>references/</code> for the word list, the pattern list, or examples.</p>
+          <pre><code><span class="c-comment"># attach as project files</span>
+SKILL.md
+references/words.md
+references/patterns.md
+references/examples.md</code></pre>
+          <button class="copy" type="button" data-copy>copy</button>
+        </div>
+        <div class="inst-pane" data-inst-pane="chat">
+          <p>paste the key parts of <code>SKILL.md</code> into a project instruction, custom instruction, or the first message of a thread.</p>
+          <pre><code><span class="c-comment"># trigger phrases</span>
+rewrite this with stop slop
+audit this for ai writing patterns
+detect only. do not rewrite
+use stop slop on this memo</code></pre>
+          <button class="copy" type="button" data-copy>copy</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="repo-tree">
+      <header>repo contents</header>
+<pre><code>stop-slop-public/
+├── SKILL.md
+├── references/
+│   ├── words.md
+│   ├── patterns.md
+│   └── examples.md
+├── ATTRIBUTION.md
+├── LICENSE
+└── README.md</code></pre>
+    </div>
+  </div>
+</section>
+
+<!-- CREDITS -->
+<section id="credits" class="section credits" aria-labelledby="cr-title">
+  <div class="wrap">
+    <div class="sec-head">
+      <span class="sec-num">§ 09</span>
+      <h2 id="cr-title" class="sec-title">credits.</h2>
+      <p class="sec-kicker">this is a fresh public consolidation. it takes inspiration from the following public work.</p>
+    </div>
+
+    <ul class="cred-grid">
+      <li class="cred">
+        <span class="cred-kind">primary</span>
+        <h3>Hardik Pandya</h3>
+        <p class="cred-repo"><a href="https://github.com/hardikpandya/stop-slop" target="_blank" rel="noopener">hardikpandya/stop-slop <span aria-hidden="true">↗</span></a></p>
+        <p class="cred-note">public framing of a compact anti-slop skill, skill packaging, examples-first approach.</p>
+        <span class="cred-lic">mit</span>
+      </li>
+      <li class="cred">
+        <span class="cred-kind">primary</span>
+        <h3>Conor Bronsdon</h3>
+        <p class="cred-repo"><a href="https://github.com/conorbronsdon/avoid-ai-writing" target="_blank" rel="noopener">conorbronsdon/avoid-ai-writing <span aria-hidden="true">↗</span></a></p>
+        <p class="cred-note">stronger rewrite vs detect split, broader audit framing, pattern clustering, richer public documentation.</p>
+        <span class="cred-lic">mit</span>
+      </li>
+      <li class="cred">
+        <span class="cred-kind">primary</span>
+        <h3>Siqi Chen</h3>
+        <p class="cred-repo"><a href="https://github.com/blader/humanizer" target="_blank" rel="noopener">blader/humanizer <span aria-hidden="true">↗</span></a></p>
+        <p class="cred-note">emphasis on voice calibration, second-pass checking, and wikipedia-informed pattern review.</p>
+        <span class="cred-lic">mit</span>
+      </li>
+      <li class="cred">
+        <span class="cred-kind">additional</span>
+        <h3>Jalaaldeen</h3>
+        <p class="cred-repo"><a href="https://github.com/jalaalrd/anti-ai-slop-writing" target="_blank" rel="noopener">jalaalrd/anti-ai-slop-writing <span aria-hidden="true">↗</span></a></p>
+        <p class="cred-note">pattern grouping ideas and public anti-slop framing. inspiration only.</p>
+        <span class="cred-lic">mit*</span>
+      </li>
+    </ul>
+
+    <p class="cred-foot">
+      this repo uses original wording written for public release. if any maintainer wants a wording change, stronger credit, or narrower attribution, open an issue.
+    </p>
+  </div>
+</section>
+
+</main>
+
+<footer class="foot">
+  <div class="wrap foot-wrap">
+    <div class="foot-col">
+      <a class="wordmark wordmark-sm" href="#top" aria-label="stop slop">
+        <span class="wm-stop">stop</span><span class="wm-sep">/</span><span class="wm-slop">slop</span><span class="wm-dot">.</span>
+      </a>
+      <p class="foot-tag">a baseline editing skill. not a personal voice layer.</p>
+    </div>
+    <div class="foot-col foot-links">
+      <a href="https://github.com/welttowelt/stop-slop-refined" target="_blank" rel="noopener">github</a>
+      <a href="https://github.com/welttowelt/stop-slop-refined/blob/main/SKILL.md" target="_blank" rel="noopener">skill.md</a>
+      <a href="https://github.com/welttowelt/stop-slop-refined/blob/main/ATTRIBUTION.md" target="_blank" rel="noopener">attribution</a>
+      <a href="https://github.com/welttowelt/stop-slop-refined/blob/main/LICENSE" target="_blank" rel="noopener">license</a>
+    </div>
+    <div class="foot-col foot-meta">
+      <p>mit. written for public use.</p>
+      <p class="foot-set">set in <em>fraunces</em>, inter, and jetbrains mono.</p>
+    </div>
+  </div>
+</footer>
+
+<script src="app.js"></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -198,7 +198,7 @@
   <div class="wrap">
     <div class="sec-head">
       <span class="sec-num">§ 03</span>
-      <h2 id="det-title" class="sec-title">live detector.</h2>
+      <h2 id="det-title" class="sec-title">quick detector.</h2>
       <p class="sec-kicker">paste prose on the left. flags appear on the right.</p>
     </div>
 
@@ -233,6 +233,7 @@ In conclusion, the future looks bright as we move forward.</textarea>
           <li><span class="sw sw-open"></span> bad opener</li>
         </ul>
         <div class="det-score" data-det-score></div>
+        <p class="modes-note">this demo checks a curated subset of the rules. <code>SKILL.md</code> and the files under <code>references/</code> stay the source of truth.</p>
       </div>
     </div>
   </div>
@@ -406,13 +407,13 @@ In conclusion, the future looks bright as we move forward.</textarea>
         <div class="inst-pane active" data-inst-pane="claude">
           <pre><code><span class="c-comment"># ~/.claude/skills/stop-slop</span>
 mkdir -p ~/.claude/skills
-cp -R stop-slop-public ~/.claude/skills/stop-slop</code></pre>
+git clone https://github.com/welttowelt/stop-slop-refined.git ~/.claude/skills/stop-slop</code></pre>
           <button class="copy" type="button" data-copy>copy</button>
         </div>
         <div class="inst-pane" data-inst-pane="codex">
           <pre><code><span class="c-comment"># ~/.codex/skills/stop-slop</span>
 mkdir -p ~/.codex/skills
-cp -R stop-slop-public ~/.codex/skills/stop-slop</code></pre>
+git clone https://github.com/welttowelt/stop-slop-refined.git ~/.codex/skills/stop-slop</code></pre>
           <button class="copy" type="button" data-copy>copy</button>
         </div>
         <div class="inst-pane" data-inst-pane="projects">
@@ -438,7 +439,7 @@ use stop slop on this memo</code></pre>
 
     <div class="repo-tree">
       <header>repo contents</header>
-<pre><code>stop-slop-public/
+<pre><code>stop-slop-refined/
 ├── SKILL.md
 ├── references/
 │   ├── words.md

--- a/docs/site-data.js
+++ b/docs/site-data.js
@@ -1,0 +1,498 @@
+// generated from references/words.md and references/patterns.md
+// do not edit by hand. run `node scripts/generate-site-data.mjs`.
+window.STOP_SLOP_DATA = {
+  "tier1": [
+    [
+      "delve / delve into",
+      "explore, examine, look at"
+    ],
+    [
+      "utilize",
+      "use"
+    ],
+    [
+      "robust",
+      "strong, reliable, solid"
+    ],
+    [
+      "comprehensive",
+      "complete, thorough"
+    ],
+    [
+      "pivotal",
+      "important, central"
+    ],
+    [
+      "transformative",
+      "describe what changed"
+    ],
+    [
+      "landscape",
+      "field, market, space"
+    ],
+    [
+      "tapestry",
+      "describe the actual complexity"
+    ],
+    [
+      "paradigm",
+      "model, approach"
+    ],
+    [
+      "embark",
+      "start, begin"
+    ],
+    [
+      "beacon",
+      "rewrite the sentence"
+    ],
+    [
+      "testament to",
+      "shows, proves"
+    ],
+    [
+      "seamless",
+      "smooth, simple, without friction"
+    ],
+    [
+      "impactful",
+      "effective, meaningful"
+    ],
+    [
+      "actionable",
+      "practical, concrete"
+    ],
+    [
+      "thought leader",
+      "expert, operator, researcher"
+    ],
+    [
+      "best practices",
+      "what works, standard approach"
+    ],
+    [
+      "in order to",
+      "to"
+    ],
+    [
+      "due to the fact that",
+      "because"
+    ],
+    [
+      "serves as",
+      "is"
+    ],
+    [
+      "boasts",
+      "has"
+    ],
+    [
+      "commence",
+      "start"
+    ],
+    [
+      "ascertain",
+      "determine, find out"
+    ],
+    [
+      "endeavor",
+      "effort, attempt"
+    ],
+    [
+      "deep dive",
+      "look at, examine"
+    ],
+    [
+      "unpack",
+      "explain, break down"
+    ],
+    [
+      "ever-evolving",
+      "changing"
+    ],
+    [
+      "watershed moment",
+      "turning point"
+    ],
+    [
+      "at its core",
+      "cut it and state the point"
+    ]
+  ],
+  "tier2": [
+    [
+      "harness",
+      "use"
+    ],
+    [
+      "navigate",
+      "handle, work through"
+    ],
+    [
+      "elevate",
+      "improve"
+    ],
+    [
+      "empower",
+      "enable"
+    ],
+    [
+      "streamline",
+      "simplify"
+    ],
+    [
+      "bolster",
+      "strengthen, support"
+    ],
+    [
+      "spearhead",
+      "lead"
+    ],
+    [
+      "resonate",
+      "connect, land"
+    ],
+    [
+      "ecosystem",
+      "network, market, community, system"
+    ],
+    [
+      "myriad",
+      "many"
+    ],
+    [
+      "plethora",
+      "many"
+    ],
+    [
+      "encompass",
+      "include"
+    ],
+    [
+      "catalyze",
+      "trigger, start"
+    ],
+    [
+      "cultivate",
+      "build, grow"
+    ],
+    [
+      "illuminate",
+      "clarify"
+    ],
+    [
+      "cornerstone",
+      "foundation"
+    ],
+    [
+      "paramount",
+      "most important"
+    ],
+    [
+      "poised",
+      "ready"
+    ],
+    [
+      "nascent",
+      "early, new"
+    ],
+    [
+      "overarching",
+      "main, broad"
+    ],
+    [
+      "augment",
+      "add to"
+    ]
+  ],
+  "tier3": [
+    "significant",
+    "effective",
+    "dynamic",
+    "scalable",
+    "compelling",
+    "valuable",
+    "key",
+    "vital",
+    "remarkable",
+    "sophisticated"
+  ],
+  "openers": [
+    "Certainly,",
+    "Absolutely,",
+    "Of course,",
+    "Great question,",
+    "Moreover,",
+    "Furthermore,",
+    "Additionally,",
+    "Importantly,",
+    "Interestingly,"
+  ],
+  "fillers": [
+    "Here's the thing",
+    "It turns out",
+    "The truth is",
+    "Let me be clear",
+    "It's worth noting",
+    "At the end of the day",
+    "When it comes to",
+    "In today's [x]",
+    "The future looks bright",
+    "Only time will tell",
+    "As we move forward",
+    "I hope this helps",
+    "Let me know if...",
+    "Without further ado",
+    "In conclusion",
+    "In summary"
+  ],
+  "patterns": [
+    {
+      "group": "sentence",
+      "title": "binary contrast",
+      "examples": [
+        "not x, but y",
+        "the real issue is not x. it's y."
+      ],
+      "fix": "state `y` directly."
+    },
+    {
+      "group": "sentence",
+      "title": "negative listing",
+      "examples": [
+        "not a tool. not a workflow. a mindset."
+      ],
+      "fix": "say the actual point without the runway."
+    },
+    {
+      "group": "sentence",
+      "title": "rhetorical question transition",
+      "examples": [
+        "so why does this matter?",
+        "but what does this mean for teams?"
+      ],
+      "fix": "if you know the answer, say it."
+    },
+    {
+      "group": "sentence",
+      "title": "signposting",
+      "examples": [
+        "let's dive in",
+        "in this section",
+        "here's what you need to know"
+      ],
+      "fix": "cut the announcement and start with the point."
+    },
+    {
+      "group": "sentence",
+      "title": "reasoning-chain leakage",
+      "examples": [
+        "let me think step by step",
+        "working through this logically",
+        "step 1:"
+      ],
+      "fix": "give the conclusion, then the reasoning."
+    },
+    {
+      "group": "structural",
+      "title": "rule of three everywhere",
+      "examples": [],
+      "fix": "use one, two, or four when that fits better."
+    },
+    {
+      "group": "structural",
+      "title": "uniform sentence length",
+      "examples": [],
+      "fix": "vary rhythm on purpose."
+    },
+    {
+      "group": "structural",
+      "title": "uniform paragraph shape",
+      "examples": [],
+      "fix": "vary openings, paragraph length, and landing points."
+    },
+    {
+      "group": "structural",
+      "title": "heading plus restatement",
+      "examples": [
+        "heading: `performance",
+        "next line: `performance matters."
+      ],
+      "fix": "let the heading do its job."
+    },
+    {
+      "group": "structural",
+      "title": "list inflation",
+      "examples": [
+        "5 ways ai is changing x",
+        "each bullet says almost nothing"
+      ],
+      "fix": "cut to the few points that actually matter."
+    },
+    {
+      "group": "voice",
+      "title": "false agency",
+      "examples": [
+        "the data tells us",
+        "the market decided",
+        "the complaint became a fix"
+      ],
+      "fix": "name the human actor when the actor matters."
+    },
+    {
+      "group": "voice",
+      "title": "vague attribution",
+      "examples": [
+        "experts believe",
+        "research shows",
+        "industry observers note"
+      ],
+      "fix": "cite the source or cut the claim."
+    },
+    {
+      "group": "voice",
+      "title": "significance inflation",
+      "examples": [
+        "a pivotal moment in the evolution of",
+        "a watershed moment",
+        "a testament to"
+      ],
+      "fix": "describe what happened and stop."
+    },
+    {
+      "group": "voice",
+      "title": "promotional description",
+      "examples": [
+        "vibrant hub",
+        "thriving ecosystem",
+        "nestled in"
+      ],
+      "fix": "describe the thing plainly."
+    },
+    {
+      "group": "voice",
+      "title": "emotional flatline",
+      "examples": [
+        "what surprised me most was",
+        "i was fascinated to discover"
+      ],
+      "fix": "make the content create the feeling."
+    },
+    {
+      "group": "formatting",
+      "title": "em dash overuse",
+      "examples": [],
+      "fix": ""
+    },
+    {
+      "group": "formatting",
+      "title": "bold spam",
+      "examples": [],
+      "fix": ""
+    },
+    {
+      "group": "formatting",
+      "title": "emoji bullets",
+      "examples": [],
+      "fix": ""
+    },
+    {
+      "group": "formatting",
+      "title": "markdown in plain text",
+      "examples": [],
+      "fix": ""
+    }
+  ],
+  "detectorPatterns": [
+    {
+      "label": "binary contrast",
+      "source": "\\bnot (?:a )?[\\w'-]+[,.;:]\\s+(?:it'?s\\s+)?(?:a\\s+|but\\s+)[\\w'-]+",
+      "flags": "gi"
+    },
+    {
+      "label": "negative listing",
+      "source": "(?:^|[.!?]\\s+)(?:not\\s+[^.!?]+[.!?]\\s*){2,}",
+      "flags": "gi"
+    },
+    {
+      "label": "rhetorical question transition",
+      "source": "\\b(?:so why|but what|but how) (?:does|do|is|are) this\\b",
+      "flags": "gi"
+    },
+    {
+      "label": "signposting",
+      "source": "\\blet's dive in(?:to)?\\b",
+      "flags": "gi"
+    },
+    {
+      "label": "signposting",
+      "source": "\\bin this section\\b",
+      "flags": "gi"
+    },
+    {
+      "label": "signposting",
+      "source": "\\bhere'?s what you need to know\\b",
+      "flags": "gi"
+    },
+    {
+      "label": "reasoning-chain leakage",
+      "source": "\\blet me think step by step\\b",
+      "flags": "gi"
+    },
+    {
+      "label": "reasoning-chain leakage",
+      "source": "\\bworking through this logically\\b",
+      "flags": "gi"
+    },
+    {
+      "label": "reasoning-chain leakage",
+      "source": "\\bstep 1:\\b",
+      "flags": "gi"
+    },
+    {
+      "label": "false agency",
+      "source": "\\b(?:the data|the market|the complaint|the product) (?:tells us|decided|became|knows)\\b",
+      "flags": "gi"
+    },
+    {
+      "label": "vague attribution",
+      "source": "\\b(?:experts believe|experts say|research shows|industry observers note|studies show)\\b",
+      "flags": "gi"
+    },
+    {
+      "label": "significance inflation",
+      "source": "\\b(?:a pivotal moment in the evolution of|a watershed moment|a testament to)\\b",
+      "flags": "gi"
+    },
+    {
+      "label": "promotional description",
+      "source": "\\b(?:vibrant|thriving|bustling) (?:hub|ecosystem|community)\\b",
+      "flags": "gi"
+    },
+    {
+      "label": "promotional description",
+      "source": "\\bnestled in\\b",
+      "flags": "gi"
+    },
+    {
+      "label": "emotional flatline",
+      "source": "\\bwhat surprised me most was\\b",
+      "flags": "gi"
+    },
+    {
+      "label": "emotional flatline",
+      "source": "\\bi was fascinated to discover\\b",
+      "flags": "gi"
+    },
+    {
+      "label": "em dash overuse",
+      "source": "—",
+      "flags": "g"
+    },
+    {
+      "label": "markdown in plain text",
+      "source": "\\*\\*[^*]+\\*\\*",
+      "flags": "g"
+    }
+  ]
+};

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,1616 @@
+/* =====================================================
+   stop slop — landing page
+   design system: editorial manuscript + engineered grid
+   ===================================================== */
+
+:root {
+  /* palette — light */
+  --paper: #f1ebdd;
+  --paper-2: #e8e0cd;
+  --paper-3: #d9cfb4;
+  --ink: #0f0d0a;
+  --ink-2: #1b1813;
+  --ink-soft: rgba(15, 13, 10, 0.68);
+  --ink-mute: rgba(15, 13, 10, 0.46);
+  --line: rgba(15, 13, 10, 0.14);
+  --line-soft: rgba(15, 13, 10, 0.08);
+  --red: #c23a1f;
+  --red-ink: #8a1f0b;
+  --red-wash: rgba(194, 58, 31, 0.13);
+  --amber: #c88a1a;
+  --amber-wash: rgba(200, 138, 26, 0.16);
+  --mint: #2d6a46;
+  --mint-wash: rgba(45, 106, 70, 0.13);
+  --yellow: #efd043;
+  --blue: #2a3f6e;
+
+  /* typography */
+  --serif: "Fraunces", "Iowan Old Style", "Palatino", Georgia, serif;
+  --sans: "Inter", -apple-system, "SF Pro Text", Segoe UI, system-ui, sans-serif;
+  --mono: "JetBrains Mono", "SF Mono", ui-monospace, Menlo, monospace;
+
+  /* scale */
+  --wrap: min(1280px, 92vw);
+  --wrap-narrow: min(980px, 92vw);
+  --radius: 14px;
+  --radius-sm: 8px;
+  --radius-lg: 22px;
+
+  /* motion */
+  --e-in: cubic-bezier(.2,.7,.2,1);
+  --e-out: cubic-bezier(.2,.8,.2,1);
+}
+
+[data-theme="dark"] {
+  --paper: #0d0c0a;
+  --paper-2: #151310;
+  --paper-3: #1e1b16;
+  --ink: #f2ead8;
+  --ink-2: #ede3cd;
+  --ink-soft: rgba(242, 234, 216, 0.72);
+  --ink-mute: rgba(242, 234, 216, 0.48);
+  --line: rgba(242, 234, 216, 0.14);
+  --line-soft: rgba(242, 234, 216, 0.07);
+  --red: #ff6143;
+  --red-ink: #ff4a28;
+  --red-wash: rgba(255, 97, 67, 0.16);
+  --amber: #f0b747;
+  --amber-wash: rgba(240, 183, 71, 0.18);
+  --mint: #5fc08c;
+  --mint-wash: rgba(95, 192, 140, 0.14);
+  --yellow: #ffd94a;
+  --blue: #8fa6d8;
+}
+
+/* =========== base =========== */
+
+*,
+*::before,
+*::after { box-sizing: border-box; }
+
+html {
+  scroll-behavior: smooth;
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  margin: 0;
+  background:
+    radial-gradient(1200px 600px at 8% -5%, var(--paper-2), transparent 60%),
+    radial-gradient(900px 500px at 102% 10%, var(--paper-3), transparent 55%),
+    var(--paper);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 17px;
+  line-height: 1.55;
+  font-feature-settings: "ss01", "ss02", "kern";
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  overflow-x: hidden;
+}
+
+[data-theme="dark"] body {
+  background:
+    radial-gradient(1400px 700px at 10% -10%, rgba(255, 97, 67, 0.08), transparent 60%),
+    radial-gradient(1000px 500px at 100% 5%, rgba(143, 166, 216, 0.06), transparent 60%),
+    var(--paper);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+  transition: color .2s var(--e-out);
+}
+
+button { font: inherit; }
+
+img, svg { display: block; max-width: 100%; }
+
+::selection {
+  background: var(--red);
+  color: var(--paper);
+}
+
+.wrap { width: var(--wrap); margin-inline: auto; }
+
+/* grain */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.18 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+  opacity: .22;
+  mix-blend-mode: multiply;
+}
+[data-theme="dark"] body::before { mix-blend-mode: screen; opacity: .14; }
+
+/* =========== masthead =========== */
+
+.masthead {
+  position: sticky;
+  top: 0;
+  z-index: 60;
+  border-bottom: 1px solid var(--line);
+  backdrop-filter: blur(14px) saturate(1.2);
+  -webkit-backdrop-filter: blur(14px) saturate(1.2);
+  background: color-mix(in srgb, var(--paper) 78%, transparent);
+}
+.masthead .wrap {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 14px 0;
+}
+
+.wordmark {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0;
+  font-family: var(--serif);
+  font-weight: 800;
+  font-size: 20px;
+  letter-spacing: -0.01em;
+}
+.wordmark .wm-stop { color: var(--ink); }
+.wordmark .wm-sep { color: var(--red); padding: 0 3px; font-weight: 300; }
+.wordmark .wm-slop {
+  color: var(--red);
+  font-style: italic;
+  text-decoration: line-through;
+  text-decoration-color: var(--red);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 0;
+}
+.wordmark .wm-dot { color: var(--ink); }
+.wordmark-sm { font-size: 22px; }
+
+.nav {
+  display: flex;
+  gap: 26px;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  letter-spacing: 0.02em;
+  text-transform: lowercase;
+  color: var(--ink-soft);
+}
+.nav a { position: relative; }
+.nav a::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; bottom: -4px;
+  height: 1px;
+  background: var(--red);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform .24s var(--e-out);
+}
+.nav a:hover { color: var(--ink); }
+.nav a:hover::after { transform: scaleX(1); }
+
+.mast-right { display: flex; align-items: center; gap: 10px; }
+
+.theme {
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--ink);
+  border-radius: 50%;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  font-size: 14px;
+  transition: background .2s var(--e-out), border-color .2s var(--e-out);
+}
+.theme:hover { background: var(--paper-2); border-color: var(--ink-mute); }
+.theme .t-light { display: block; }
+.theme .t-dark { display: none; }
+[data-theme="dark"] .theme .t-light { display: none; }
+[data-theme="dark"] .theme .t-dark { display: block; }
+
+.gh {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  letter-spacing: 0.04em;
+  padding: 8px 13px;
+  border: 1px solid var(--ink);
+  border-radius: 999px;
+  background: var(--ink);
+  color: var(--paper);
+  transition: transform .2s var(--e-out), background .2s var(--e-out);
+}
+.gh:hover { transform: translateY(-1px); background: var(--red); border-color: var(--red); }
+
+/* =========== hero =========== */
+
+.hero {
+  position: relative;
+  padding: clamp(40px, 8vw, 110px) 0 clamp(60px, 10vw, 140px);
+  overflow: hidden;
+}
+.hero-wrap {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1.08fr) minmax(0, .92fr);
+  grid-template-areas:
+    "meta   meta"
+    "title  demo"
+    "body   demo";
+  gap: clamp(20px, 3vw, 40px) clamp(28px, 4.5vw, 64px);
+  align-items: start;
+}
+
+.hero-meta {
+  grid-area: meta;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  letter-spacing: 0.06em;
+  text-transform: lowercase;
+  margin-bottom: 6px;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--ink-soft);
+  background: color-mix(in srgb, var(--paper) 70%, transparent);
+}
+.tag .dot {
+  width: 6px; height: 6px;
+  background: var(--red);
+  border-radius: 50%;
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--red) 60%, transparent);
+  animation: pulse 2.6s var(--e-out) infinite;
+}
+@keyframes pulse {
+  0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--red) 55%, transparent); }
+  50% { box-shadow: 0 0 0 8px rgba(194, 58, 31, 0); }
+}
+.tag-live { color: var(--ink); border-color: var(--ink-mute); }
+
+.display {
+  grid-area: title;
+  margin: 0;
+  font-family: var(--serif);
+  font-weight: 800;
+  line-height: 0.86;
+  letter-spacing: -0.03em;
+  font-size: clamp(5.6rem, 14vw, 13.5rem);
+  color: var(--ink);
+}
+.display .d-line {
+  display: block;
+  position: relative;
+}
+.display .d-line em {
+  position: relative;
+  font-style: italic;
+  font-weight: 900;
+  color: var(--red);
+  display: inline-block;
+}
+.display .slant {
+  padding-left: clamp(30px, 6vw, 92px);
+  position: relative;
+}
+.display .slant em::after {
+  content: "";
+  position: absolute;
+  left: -4px;
+  right: -6px;
+  top: 52%;
+  height: clamp(9px, 1.1vw, 16px);
+  transform: rotate(-4deg);
+  background: var(--red);
+  border-radius: 2px;
+  transform-origin: left center;
+  animation: strike 1.1s var(--e-out) .55s both;
+  pointer-events: none;
+  box-shadow: 0 2px 0 rgba(0,0,0,0.04);
+}
+.display .slant .mark { display: none; }
+@keyframes strike {
+  from { transform: rotate(-4deg) scaleX(0); }
+  to   { transform: rotate(-4deg) scaleX(1); }
+}
+.display .small {
+  font-size: clamp(1.4rem, 2.6vw, 2.2rem);
+  font-weight: 400;
+  font-style: italic;
+  color: var(--ink-soft);
+  letter-spacing: -0.01em;
+  padding-left: clamp(2px, 0.4vw, 6px);
+  margin-top: clamp(8px, 1.2vw, 16px);
+}
+
+.hero-body {
+  grid-area: body;
+  max-width: 42ch;
+}
+.lede {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: clamp(1.25rem, 1.9vw, 1.6rem);
+  line-height: 1.35;
+  letter-spacing: -0.01em;
+  margin: 0 0 14px;
+}
+.deck {
+  font-size: clamp(1rem, 1.3vw, 1.08rem);
+  color: var(--ink-soft);
+  margin: 0 0 28px;
+}
+
+.cta-row { display: flex; flex-wrap: wrap; gap: 10px; }
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 13px 20px;
+  border-radius: 999px;
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  text-transform: lowercase;
+  transition: transform .2s var(--e-out), background .2s var(--e-out), color .2s var(--e-out), border-color .2s var(--e-out);
+  will-change: transform;
+  white-space: nowrap;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+.btn-primary {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+}
+.btn-primary:hover {
+  transform: translateY(-2px);
+  background: var(--red);
+  border-color: var(--red);
+}
+.btn-ghost {
+  background: transparent;
+  color: var(--ink);
+  border-color: var(--ink-mute);
+}
+.btn-ghost:hover {
+  transform: translateY(-2px);
+  border-color: var(--ink);
+  background: var(--paper-2);
+}
+.btn-sm { padding: 8px 14px; font-size: 11.5px; }
+
+/* hero demo */
+
+.hero-demo {
+  grid-area: demo;
+  align-self: stretch;
+  margin: 0;
+  background:
+    linear-gradient(to bottom, var(--paper-2), var(--paper));
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  padding: 18px 18px 16px;
+  display: flex;
+  flex-direction: column;
+  min-height: 440px;
+  position: relative;
+  box-shadow:
+    0 1px 0 var(--line) inset,
+    0 30px 60px -40px rgba(15, 13, 10, 0.25);
+  overflow: hidden;
+}
+[data-theme="dark"] .hero-demo {
+  box-shadow:
+    0 1px 0 var(--line) inset,
+    0 30px 60px -20px rgba(0,0,0,0.6);
+}
+.hero-demo::before {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; top: 0; bottom: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(to bottom, transparent calc(100% - 1px), var(--line-soft) 100%);
+  background-size: 100% 28px;
+  background-position: 0 48px;
+  opacity: 0.55;
+  mask-image: linear-gradient(to bottom, transparent 48px, black 96px, black calc(100% - 40px), transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, transparent 48px, black 96px, black calc(100% - 40px), transparent 100%);
+}
+.demo-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+  color: var(--ink-mute);
+  padding: 4px 8px 12px;
+  border-bottom: 1px dashed var(--line);
+  position: relative;
+  z-index: 1;
+}
+.d-title { color: var(--ink); font-weight: 600; }
+.demo-stage {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: start;
+  gap: 16px;
+  padding: 22px 8px 16px;
+  position: relative;
+  z-index: 1;
+}
+.demo-side { min-width: 0; }
+.side-label {
+  display: block;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  margin-bottom: 10px;
+}
+.demo-before blockquote,
+.demo-after blockquote {
+  font-family: var(--serif);
+  font-size: clamp(0.98rem, 1.18vw, 1.08rem);
+  line-height: 1.45;
+  margin: 0;
+  color: var(--ink);
+  font-style: italic;
+  font-weight: 400;
+}
+.demo-before blockquote .strike {
+  background: linear-gradient(transparent 45%, var(--red) 45%, var(--red) 56%, transparent 56%);
+  color: var(--red-ink);
+}
+.demo-before blockquote .highlight {
+  background: linear-gradient(transparent 65%, var(--red-wash) 65%);
+  padding: 0 2px;
+  margin: 0 -2px;
+}
+.demo-after blockquote {
+  color: var(--ink);
+  font-style: normal;
+  font-weight: 500;
+}
+.demo-after blockquote .kept {
+  background: linear-gradient(transparent 65%, var(--mint-wash) 65%);
+  padding: 0 2px;
+  margin: 0 -2px;
+}
+.demo-divider {
+  color: var(--ink-mute);
+  width: 36px; height: 36px;
+  align-self: center;
+  margin-top: 16px;
+}
+.demo-foot {
+  padding: 14px 8px 2px;
+  border-top: 1px dashed var(--line);
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  justify-content: space-between;
+  position: relative;
+  z-index: 1;
+}
+.demo-changes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.demo-changes li {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.03em;
+  padding: 4px 9px;
+  background: var(--red-wash);
+  color: var(--red-ink);
+  border-radius: 999px;
+}
+.demo-next {
+  border: 1px solid var(--line);
+  background: var(--paper);
+  color: var(--ink);
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: all .2s var(--e-out);
+  flex-shrink: 0;
+}
+.demo-next:hover { background: var(--ink); color: var(--paper); border-color: var(--ink); }
+
+/* baseline ruled texture on hero */
+.hero .rules {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(to bottom, transparent calc(100% - 1px), var(--line-soft) 100%);
+  background-size: 100% 36px;
+  opacity: 0.35;
+  mask-image: linear-gradient(to bottom, transparent 0, black 40%, black 60%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0, black 40%, black 60%, transparent 100%);
+}
+
+/* =========== generic section =========== */
+
+.section {
+  position: relative;
+  padding: clamp(64px, 9vw, 120px) 0;
+  border-top: 1px solid var(--line);
+}
+.sec-head {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto auto;
+  column-gap: 28px;
+  row-gap: 10px;
+  align-items: baseline;
+  margin-bottom: clamp(32px, 4vw, 60px);
+  max-width: 1200px;
+}
+.sec-num {
+  grid-row: 1 / span 2;
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+  color: var(--ink-mute);
+  padding-top: 18px;
+  border-top: 1px solid var(--ink);
+  width: 72px;
+}
+[data-theme="dark"] .sec-num { border-top-color: var(--ink-2); }
+.sec-title {
+  margin: 0;
+  font-family: var(--serif);
+  font-weight: 800;
+  font-size: clamp(2.2rem, 4.6vw, 4.4rem);
+  letter-spacing: -0.03em;
+  line-height: 0.95;
+  color: var(--ink);
+}
+.sec-kicker {
+  margin: 0;
+  grid-column: 2;
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(1.02rem, 1.45vw, 1.22rem);
+  line-height: 1.4;
+  color: var(--ink-soft);
+  max-width: 60ch;
+}
+
+/* =========== what =========== */
+
+.what-grid {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 1px;
+  background: var(--line);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+.what-grid li {
+  background: var(--paper);
+  padding: 26px 22px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 240px;
+  position: relative;
+  transition: background .3s var(--e-out);
+}
+.what-grid li:hover { background: var(--paper-2); }
+.what-grid li:nth-child(1),
+.what-grid li:nth-child(2) { grid-column: span 3; }
+.what-grid li:nth-child(3),
+.what-grid li:nth-child(4) { grid-column: span 2; }
+.what-grid li:nth-child(5) { grid-column: span 2; background: var(--ink); color: var(--paper); }
+.what-grid li:nth-child(5):hover { background: var(--red); }
+.what-grid li:nth-child(5) .num { color: var(--paper); opacity: 0.5; }
+.what-grid li:nth-child(5) p { color: rgba(241, 235, 221, 0.72); }
+.what-grid .num {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: var(--ink-mute);
+}
+.what-grid h3 {
+  margin: 0;
+  font-family: var(--serif);
+  font-weight: 600;
+  font-size: clamp(1.28rem, 1.8vw, 1.55rem);
+  line-height: 1.15;
+  letter-spacing: -0.015em;
+}
+.what-grid p {
+  margin: auto 0 0;
+  font-size: 0.95rem;
+  color: var(--ink-soft);
+  line-height: 1.5;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 9px;
+  border-radius: 999px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  letter-spacing: 0.04em;
+  text-transform: lowercase;
+}
+.pill-ink { background: var(--ink); color: var(--paper); }
+.pill-out { background: transparent; color: var(--ink); border: 1px solid var(--line); }
+
+/* =========== modes =========== */
+
+.modes-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+.mode {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 32px 32px 26px;
+  background: var(--paper-2);
+  position: relative;
+  overflow: hidden;
+  transition: transform .3s var(--e-out), border-color .3s var(--e-out);
+}
+.mode:hover { transform: translateY(-3px); border-color: var(--ink-mute); }
+.mode::before {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; top: 0;
+  height: 4px;
+}
+.mode-rewrite::before { background: var(--ink); }
+.mode-detect::before  { background: var(--red); }
+
+.mode header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+.mode-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.mode h3 {
+  margin: 0;
+  font-family: var(--serif);
+  font-weight: 800;
+  font-size: clamp(1.8rem, 2.4vw, 2.4rem);
+  letter-spacing: -0.02em;
+}
+.mode ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.mode ul li {
+  font-family: var(--serif);
+  font-size: 1.05rem;
+  line-height: 1.45;
+  color: var(--ink);
+  padding: 10px 0;
+  border-bottom: 1px dashed var(--line);
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+}
+.mode ul li:last-child { border-bottom: none; }
+.mode ul li::before {
+  content: "→";
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--red);
+  flex-shrink: 0;
+}
+.mode footer {
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid var(--line);
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.mode-out {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.mode footer code {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  color: var(--ink);
+  background: var(--paper);
+  padding: 5px 9px;
+  border-radius: 6px;
+  border: 1px solid var(--line);
+}
+
+.modes-note {
+  margin: 22px 0 0;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--ink-soft);
+  letter-spacing: 0.02em;
+}
+.kbd {
+  display: inline-block;
+  padding: 2px 7px;
+  font-family: var(--mono);
+  font-size: 11px;
+  border: 1px solid var(--line);
+  border-bottom-width: 2px;
+  border-radius: 5px;
+  background: var(--paper);
+  color: var(--ink);
+  margin: 0 2px;
+}
+
+/* =========== detector =========== */
+
+.det-stage {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 28px;
+  align-items: stretch;
+}
+.det-label {
+  display: block;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  margin-bottom: 10px;
+}
+.det-input-box {
+  position: relative;
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  min-height: 320px;
+  overflow: hidden;
+}
+.det-input-box textarea {
+  width: 100%;
+  min-height: 320px;
+  border: 0;
+  outline: 0;
+  resize: vertical;
+  font-family: var(--serif);
+  font-size: 1.05rem;
+  line-height: 1.55;
+  color: var(--ink);
+  background: transparent;
+  padding: 22px;
+}
+.det-input-box textarea::placeholder { color: var(--ink-mute); }
+.det-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 12px;
+}
+.det-counts {
+  margin-left: auto;
+  display: flex;
+  gap: 16px;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--ink-mute);
+}
+.det-counts b {
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.det-output {
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 22px;
+  min-height: 320px;
+  font-family: var(--serif);
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: var(--ink);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* highlight swatches in detector */
+.hl { padding: 1px 3px; border-radius: 4px; position: relative; cursor: help; }
+.hl-t1 { background: var(--red-wash); color: var(--red-ink); text-decoration: line-through; text-decoration-color: var(--red); text-decoration-thickness: 2px; }
+.hl-t2 { background: var(--amber-wash); color: var(--ink); box-shadow: inset 0 -2px 0 var(--amber); }
+.hl-t3 { background: linear-gradient(transparent 65%, var(--line) 65%); color: var(--ink); }
+.hl-pat { background: var(--red-wash); color: var(--red-ink); border: 1px dashed var(--red); border-radius: 4px; }
+.hl-open { background: var(--amber-wash); color: var(--ink); border-bottom: 1px dashed var(--amber); }
+
+.det-legend {
+  margin: 14px 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--ink-soft);
+}
+.det-legend li {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.sw {
+  display: inline-block;
+  width: 14px; height: 14px;
+  border-radius: 4px;
+}
+.sw-t1 { background: var(--red-wash); border: 1px solid var(--red); }
+.sw-t2 { background: var(--amber-wash); border: 1px solid var(--amber); }
+.sw-t3 { background: transparent; border-bottom: 2px solid var(--line); border-radius: 0; height: 4px; align-self: baseline; margin-bottom: 4px; }
+.sw-pat { background: var(--red-wash); border: 1px dashed var(--red); }
+.sw-open { background: var(--amber-wash); border-bottom: 1px dashed var(--amber); border-radius: 0; height: 6px; align-self: center; }
+
+.det-score {
+  margin-top: 16px;
+  padding: 14px 18px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1.02rem;
+  color: var(--ink);
+  min-height: 54px;
+  display: flex;
+  align-items: center;
+}
+.det-score .score-strong { font-style: normal; font-weight: 700; color: var(--red); }
+.det-score .score-neutral { font-style: normal; font-weight: 700; color: var(--amber); }
+.det-score .score-clean { font-style: normal; font-weight: 700; color: var(--mint); }
+
+/* =========== examples =========== */
+
+.ex-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 28px;
+  counter-reset: ex;
+}
+.ex {
+  counter-increment: ex;
+  position: relative;
+  display: grid;
+  grid-template-columns: 72px 1fr 1fr;
+  gap: 20px;
+  padding: 24px 24px 28px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper-2);
+  transition: transform .3s var(--e-out), border-color .3s var(--e-out);
+}
+.ex:hover { transform: translateY(-2px); border-color: var(--ink-mute); }
+.ex::before {
+  content: "№ 0" counter(ex);
+  grid-column: 1;
+  grid-row: 1 / span 2;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  color: var(--ink-mute);
+  padding-top: 4px;
+  border-right: 1px solid var(--line);
+  padding-right: 16px;
+}
+.ex-before, .ex-after {
+  font-family: var(--serif);
+  font-size: 1.08rem;
+  line-height: 1.5;
+}
+.ex-before {
+  color: var(--ink);
+}
+.ex-before del {
+  text-decoration: line-through;
+  text-decoration-color: var(--red);
+  text-decoration-thickness: 2px;
+  color: var(--ink-mute);
+}
+.ex-before mark {
+  background: var(--red-wash);
+  color: var(--red-ink);
+  padding: 0 3px;
+  border-radius: 3px;
+}
+.ex-after {
+  color: var(--ink);
+  font-weight: 500;
+  padding-left: 18px;
+  border-left: 3px solid var(--mint);
+  font-style: italic;
+}
+.ex-side-label {
+  display: block;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  margin-bottom: 10px;
+  font-weight: 500;
+}
+.ex-after .ex-side-label { color: var(--mint); }
+.ex-changes {
+  grid-column: 2 / -1;
+  margin: 0;
+  padding: 14px 0 0;
+  border-top: 1px dashed var(--line);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  list-style: none;
+}
+.ex-changes li {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  padding: 4px 9px;
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--ink-soft);
+}
+.ex-changes li::before { content: "·  "; color: var(--red); font-weight: 700; }
+
+/* =========== words / tiers =========== */
+
+.tiers {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+.tier {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 24px 22px;
+  background: var(--paper-2);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  position: relative;
+  overflow: hidden;
+}
+.tier::before {
+  content: "";
+  position: absolute;
+  top: 0; left: 0; right: 0; height: 4px;
+}
+.tier-1::before { background: var(--red); }
+.tier-2::before { background: var(--amber); }
+.tier-3::before { background: var(--ink-mute); }
+
+.tier header h3 {
+  margin: 0;
+  font-family: var(--serif);
+  font-weight: 700;
+  font-size: 1.5rem;
+  letter-spacing: -0.02em;
+}
+.tier-tag {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  margin-bottom: 6px;
+}
+.tier header p {
+  margin: 6px 0 0;
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--ink-soft);
+  font-size: 0.98rem;
+  line-height: 1.45;
+}
+.tier-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.wpill {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 5px 10px;
+  border-radius: 6px;
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.01em;
+  border: 1px solid var(--line);
+  background: var(--paper);
+  color: var(--ink);
+  transition: all .2s var(--e-out);
+  cursor: default;
+}
+.wpill .arrow { color: var(--ink-mute); }
+.wpill .fix { color: var(--mint); font-family: var(--serif); font-style: italic; font-size: 12.5px; }
+.wpill:hover { transform: translateY(-1px); border-color: var(--ink); }
+
+.tier-1 .wpill { border-color: rgba(194, 58, 31, 0.35); }
+.tier-1 .wpill:hover { border-color: var(--red); background: var(--red-wash); }
+.tier-2 .wpill { border-color: rgba(200, 138, 26, 0.4); }
+.tier-2 .wpill:hover { border-color: var(--amber); background: var(--amber-wash); }
+
+.openers-fillers {
+  margin-top: 32px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  padding-top: 24px;
+  border-top: 1px dashed var(--line);
+}
+.of-col h4 {
+  margin: 0 0 12px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.of-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.ofpill {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 0.97rem;
+  padding: 4px 10px 5px;
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--ink);
+  text-decoration: line-through;
+  text-decoration-color: var(--red);
+  text-decoration-thickness: 1.5px;
+}
+
+/* =========== patterns =========== */
+
+.pat-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+.pat {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 22px;
+  background: var(--paper-2);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 220px;
+  transition: transform .3s var(--e-out), border-color .3s var(--e-out);
+}
+.pat:hover { transform: translateY(-2px); border-color: var(--ink-mute); }
+.pat header { display: flex; align-items: baseline; gap: 10px; justify-content: space-between; }
+.pat-group {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.pat h3 {
+  margin: 0;
+  font-family: var(--serif);
+  font-weight: 700;
+  font-size: 1.22rem;
+  letter-spacing: -0.015em;
+}
+.pat .eg {
+  margin: 0;
+  padding: 10px 14px;
+  background: var(--paper);
+  border-left: 3px solid var(--red);
+  border-radius: 0 6px 6px 0;
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 0.97rem;
+  color: var(--ink);
+  line-height: 1.45;
+}
+.pat .eg code {
+  font-family: var(--mono);
+  font-style: normal;
+  font-size: 0.86em;
+  background: var(--red-wash);
+  color: var(--red-ink);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+.pat .fix-line {
+  margin: 0;
+  padding-top: 10px;
+  border-top: 1px dashed var(--line);
+  font-size: 0.92rem;
+  color: var(--ink-soft);
+}
+.pat .fix-line b {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--mint);
+  margin-right: 8px;
+  font-weight: 600;
+}
+
+/* =========== severity =========== */
+
+.sev-grid {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+.sev {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 26px 24px;
+  background: var(--paper-2);
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.sev header { display: flex; align-items: baseline; gap: 12px; }
+.sev-label {
+  font-family: var(--mono);
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  padding: 4px 10px;
+  border-radius: 6px;
+  color: var(--paper);
+}
+.sev-p0 .sev-label { background: var(--red); }
+.sev-p1 .sev-label { background: var(--amber); color: #2b1d06; }
+.sev-p2 .sev-label { background: var(--ink); }
+.sev h3 {
+  margin: 0;
+  font-family: var(--serif);
+  font-weight: 700;
+  font-size: 1.35rem;
+  letter-spacing: -0.015em;
+}
+.sev ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.sev ul li {
+  font-size: 0.96rem;
+  line-height: 1.5;
+  color: var(--ink);
+  padding: 8px 0;
+  border-bottom: 1px dashed var(--line);
+}
+.sev ul li:last-child { border-bottom: none; }
+.sev-p0::before, .sev-p1::before, .sev-p2::before {
+  content: "";
+  position: absolute;
+  top: 0; left: 0; right: 0; height: 4px;
+}
+.sev-p0::before { background: var(--red); }
+.sev-p1::before { background: var(--amber); }
+.sev-p2::before { background: var(--ink); }
+
+.calib {
+  margin-top: 32px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  padding: 24px;
+  border: 1px dashed var(--line);
+  border-radius: var(--radius);
+  background: var(--paper);
+}
+.calib-col h4 {
+  margin: 0 0 12px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.calib-col ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.calib-col li {
+  font-family: var(--serif);
+  font-size: 1rem;
+  padding: 5px 12px;
+  border-radius: 999px;
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  color: var(--ink);
+}
+.calib-strict li { border-color: rgba(194, 58, 31, 0.35); }
+.calib-loose li  { border-color: rgba(45, 106, 70, 0.35); }
+
+/* =========== install =========== */
+
+.inst-panel {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: var(--paper-2);
+}
+.inst-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0;
+  border-bottom: 1px solid var(--line);
+  background: var(--paper);
+}
+.inst-tab {
+  flex: 1 1 auto;
+  min-width: 140px;
+  border: 0;
+  background: transparent;
+  color: var(--ink-soft);
+  padding: 14px 18px;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  letter-spacing: 0.04em;
+  text-transform: lowercase;
+  cursor: pointer;
+  border-right: 1px solid var(--line);
+  transition: background .2s var(--e-out), color .2s var(--e-out);
+  text-align: left;
+}
+.inst-tab:last-child { border-right: 0; }
+.inst-tab:hover { color: var(--ink); background: var(--paper-2); }
+.inst-tab.active {
+  color: var(--ink);
+  background: var(--paper-2);
+  box-shadow: inset 0 -2px 0 var(--red);
+}
+.inst-panes { padding: 22px; position: relative; }
+.inst-pane { display: none; }
+.inst-pane.active { display: block; animation: fadein .28s var(--e-out); }
+@keyframes fadein {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: none; }
+}
+.inst-pane pre {
+  margin: 0;
+  padding: 18px 20px;
+  background: var(--ink);
+  color: var(--paper);
+  border-radius: var(--radius-sm);
+  overflow-x: auto;
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.6;
+  position: relative;
+}
+.inst-pane pre code { font-family: inherit; }
+.inst-pane .c-comment { color: rgba(241, 235, 221, 0.45); }
+.inst-pane p {
+  margin: 0 0 14px;
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--ink-soft);
+  font-size: 1rem;
+}
+.inst-pane p code {
+  font-family: var(--mono);
+  font-style: normal;
+  padding: 1px 6px;
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  font-size: 0.86em;
+}
+
+.copy {
+  position: absolute;
+  top: 30px;
+  right: 30px;
+  border: 1px solid rgba(241, 235, 221, 0.25);
+  background: rgba(241, 235, 221, 0.08);
+  color: var(--paper);
+  padding: 5px 10px;
+  border-radius: 6px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  transition: all .2s var(--e-out);
+}
+.copy:hover { background: var(--red); border-color: var(--red); }
+.copy.copied { background: var(--mint); border-color: var(--mint); }
+
+.repo-tree {
+  margin-top: 22px;
+  border: 1px dashed var(--line);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+.repo-tree header {
+  padding: 10px 16px;
+  border-bottom: 1px dashed var(--line);
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.repo-tree pre {
+  margin: 0;
+  padding: 18px 20px;
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.7;
+  color: var(--ink);
+  background: transparent;
+}
+
+/* =========== credits =========== */
+
+.cred-grid {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 18px;
+}
+.cred {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 24px 22px;
+  background: var(--paper-2);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  transition: transform .3s var(--e-out), border-color .3s var(--e-out);
+  position: relative;
+  overflow: hidden;
+}
+.cred:hover { transform: translateY(-2px); border-color: var(--ink); }
+.cred-kind {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.cred h3 {
+  margin: 0;
+  font-family: var(--serif);
+  font-weight: 700;
+  font-size: 1.3rem;
+  letter-spacing: -0.015em;
+}
+.cred-repo {
+  margin: 0;
+  font-family: var(--mono);
+  font-size: 12.5px;
+}
+.cred-repo a {
+  color: var(--red);
+  border-bottom: 1px dashed var(--red);
+  padding-bottom: 1px;
+}
+.cred-repo a:hover { color: var(--ink); border-bottom-style: solid; }
+.cred-note {
+  margin: auto 0 0;
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 0.96rem;
+  color: var(--ink-soft);
+  line-height: 1.45;
+}
+.cred-lic {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 3px 7px;
+  border-radius: 4px;
+  background: var(--ink);
+  color: var(--paper);
+}
+
+.cred-foot {
+  margin: 28px 0 0;
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--ink-soft);
+  font-size: 1.02rem;
+  max-width: 72ch;
+}
+
+/* =========== footer =========== */
+
+.foot {
+  border-top: 1px solid var(--line);
+  padding: 40px 0 44px;
+  margin-top: 0;
+  background: var(--paper-2);
+}
+.foot-wrap {
+  display: grid;
+  grid-template-columns: 1.6fr 1fr 1fr;
+  gap: 30px;
+  align-items: start;
+}
+.foot .wordmark { font-size: 26px; }
+.foot-tag {
+  margin: 8px 0 0;
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1rem;
+  color: var(--ink-soft);
+  max-width: 38ch;
+}
+.foot-links {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  font-family: var(--mono);
+  font-size: 12.5px;
+}
+.foot-links a {
+  color: var(--ink-soft);
+  border-bottom: 1px dashed transparent;
+  padding-bottom: 1px;
+  width: fit-content;
+}
+.foot-links a:hover { color: var(--ink); border-bottom-color: var(--red); }
+.foot-meta {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--ink-mute);
+}
+.foot-meta p { margin: 0 0 4px; }
+.foot-meta em {
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--ink);
+  font-size: 13.5px;
+}
+.foot-set { margin-top: 8px !important; }
+
+/* =========== responsive =========== */
+
+@media (max-width: 1100px) {
+  .hero-wrap {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "meta"
+      "title"
+      "body"
+      "demo";
+  }
+  .hero-demo { margin-top: 10px; }
+  .what-grid { grid-template-columns: repeat(2, 1fr); }
+  .what-grid li:nth-child(1),
+  .what-grid li:nth-child(2),
+  .what-grid li:nth-child(3),
+  .what-grid li:nth-child(4),
+  .what-grid li:nth-child(5) { grid-column: span 1; }
+  .what-grid li:nth-child(5) { grid-column: span 2; }
+  .tiers { grid-template-columns: 1fr; }
+  .pat-grid { grid-template-columns: repeat(2, 1fr); }
+  .cred-grid { grid-template-columns: repeat(2, 1fr); }
+  .det-stage { grid-template-columns: 1fr; }
+  .foot-wrap { grid-template-columns: 1fr 1fr; }
+}
+
+@media (max-width: 720px) {
+  body { font-size: 16px; }
+  .nav { display: none; }
+  .masthead .wrap { padding: 12px 0; }
+  .modes-grid { grid-template-columns: 1fr; }
+  .sev-grid { grid-template-columns: 1fr; }
+  .pat-grid { grid-template-columns: 1fr; }
+  .cred-grid { grid-template-columns: 1fr; }
+  .what-grid { grid-template-columns: 1fr; }
+  .what-grid li:nth-child(5) { grid-column: span 1; }
+  .ex { grid-template-columns: 1fr; gap: 14px; }
+  .ex::before {
+    grid-column: 1; grid-row: 1;
+    border-right: 0; border-bottom: 1px solid var(--line);
+    padding-right: 0; padding-bottom: 8px;
+    width: 100%;
+  }
+  .ex-changes { grid-column: 1; }
+  .calib { grid-template-columns: 1fr; }
+  .openers-fillers { grid-template-columns: 1fr; }
+  .foot-wrap { grid-template-columns: 1fr; gap: 22px; }
+  .display { font-size: clamp(4.2rem, 20vw, 9rem); }
+  .sec-head { grid-template-columns: 1fr; }
+  .sec-num { grid-row: auto; width: auto; border-top: 0; padding-top: 0; }
+  .sec-kicker { grid-column: 1; }
+  .demo-stage { grid-template-columns: 1fr; }
+  .demo-divider { transform: rotate(90deg); justify-self: center; }
+}
+
+/* respect motion prefs */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    transition-duration: 0s !important;
+  }
+}

--- a/scripts/generate-site-data.mjs
+++ b/scripts/generate-site-data.mjs
@@ -1,0 +1,190 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+
+function collectSection(lines, startHeading) {
+  const start = lines.findIndex(line => line.startsWith(startHeading));
+  if (start === -1) return [];
+  const out = [];
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.startsWith("## ")) break;
+    out.push(line);
+  }
+  return out;
+}
+
+function parseWordsTable(lines) {
+  return lines
+    .filter(line => /^\|/.test(line))
+    .filter(line => !/^\|\s*---/.test(line))
+    .filter(line => !/word or phrase/.test(line))
+    .map(line => line.split("|").slice(1, -1).map(part => part.trim()))
+    .filter(parts => parts.length === 2 && parts[0] && parts[1]);
+}
+
+function parseBullets(lines) {
+  return lines
+    .filter(line => /^\s*-\s+/.test(line))
+    .map(line => line.replace(/^\s*-\s+/, "").trim())
+    .map(line => line.replace(/^`|`$/g, ""));
+}
+
+function parseWords(md) {
+  const lines = md.split(/\r?\n/);
+  return {
+    tier1: parseWordsTable(collectSection(lines, "## Tier 1:")),
+    tier2: parseWordsTable(collectSection(lines, "## Tier 2:")),
+    tier3: parseBullets(collectSection(lines, "## Tier 3:")),
+    openers: parseBullets(collectSection(lines, "## Common bad openers")),
+    fillers: parseBullets(collectSection(lines, "## Common filler phrases"))
+  };
+}
+
+function normalizeGroup(heading) {
+  const value = heading.replace(/^##\s+/, "").trim().toLowerCase();
+  if (value === "sentence patterns") return "sentence";
+  if (value === "structural patterns") return "structural";
+  if (value === "voice and stance patterns") return "voice";
+  if (value === "formatting artifacts") return "formatting";
+  return value;
+}
+
+function parsePatterns(md) {
+  const lines = md.split(/\r?\n/);
+  const patterns = [];
+  let group = "";
+  let current = null;
+  let inExamples = false;
+
+  function pushCurrent() {
+    if (current) patterns.push(current);
+  }
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    if (line.startsWith("## ")) {
+      pushCurrent();
+      current = null;
+      group = normalizeGroup(line);
+      inExamples = false;
+      continue;
+    }
+
+    if (line.startsWith("### ")) {
+      pushCurrent();
+      current = {
+        group,
+        title: line.replace(/^###\s+/, "").trim(),
+        examples: [],
+        fix: ""
+      };
+      inExamples = false;
+      continue;
+    }
+
+    if (!current) continue;
+
+    if (/^Examples?:$/i.test(line)) {
+      inExamples = true;
+      continue;
+    }
+
+    if (line.startsWith("Fix:")) {
+      current.fix = line.replace(/^Fix:\s*/, "").trim();
+      inExamples = false;
+      continue;
+    }
+
+    if (inExamples && line.startsWith("- ")) {
+      current.examples.push(line.replace(/^- /, "").trim().replace(/^`|`$/g, ""));
+    }
+  }
+
+  pushCurrent();
+  return patterns;
+}
+
+function buildDetectorPatterns(patterns) {
+  const byTitle = new Map(patterns.map(pattern => [pattern.title, pattern]));
+  const regexMap = {
+    "binary contrast": [
+      { source: "\\bnot (?:a )?[\\w'-]+[,.;:]\\s+(?:it'?s\\s+)?(?:a\\s+|but\\s+)[\\w'-]+", flags: "gi" }
+    ],
+    "negative listing": [
+      { source: "(?:^|[.!?]\\s+)(?:not\\s+[^.!?]+[.!?]\\s*){2,}", flags: "gi" }
+    ],
+    "rhetorical question transition": [
+      { source: "\\b(?:so why|but what|but how) (?:does|do|is|are) this\\b", flags: "gi" }
+    ],
+    signposting: [
+      { source: "\\blet's dive in(?:to)?\\b", flags: "gi" },
+      { source: "\\bin this section\\b", flags: "gi" },
+      { source: "\\bhere'?s what you need to know\\b", flags: "gi" }
+    ],
+    "reasoning-chain leakage": [
+      { source: "\\blet me think step by step\\b", flags: "gi" },
+      { source: "\\bworking through this logically\\b", flags: "gi" },
+      { source: "\\bstep 1:\\b", flags: "gi" }
+    ],
+    "false agency": [
+      { source: "\\b(?:the data|the market|the complaint|the product) (?:tells us|decided|became|knows)\\b", flags: "gi" }
+    ],
+    "vague attribution": [
+      { source: "\\b(?:experts believe|experts say|research shows|industry observers note|studies show)\\b", flags: "gi" }
+    ],
+    "significance inflation": [
+      { source: "\\b(?:a pivotal moment in the evolution of|a watershed moment|a testament to)\\b", flags: "gi" }
+    ],
+    "promotional description": [
+      { source: "\\b(?:vibrant|thriving|bustling) (?:hub|ecosystem|community)\\b", flags: "gi" },
+      { source: "\\bnestled in\\b", flags: "gi" }
+    ],
+    "emotional flatline": [
+      { source: "\\bwhat surprised me most was\\b", flags: "gi" },
+      { source: "\\bi was fascinated to discover\\b", flags: "gi" }
+    ],
+    "markdown in plain text": [
+      { source: "\\*\\*[^*]+\\*\\*", flags: "g" }
+    ],
+    "em dash overuse": [
+      { source: "—", flags: "g" }
+    ]
+  };
+
+  return [...byTitle.keys()].flatMap(title => {
+    const entries = regexMap[title];
+    if (!entries) return [];
+    return entries.map(entry => ({
+      label: title,
+      source: entry.source,
+      flags: entry.flags
+    }));
+  });
+}
+
+const wordsMd = await readFile(path.join(repoRoot, "references", "words.md"), "utf8");
+const patternsMd = await readFile(path.join(repoRoot, "references", "patterns.md"), "utf8");
+
+const words = parseWords(wordsMd);
+const patterns = parsePatterns(patternsMd);
+
+const data = {
+  tier1: words.tier1,
+  tier2: words.tier2,
+  tier3: words.tier3,
+  openers: words.openers,
+  fillers: words.fillers,
+  patterns,
+  detectorPatterns: buildDetectorPatterns(patterns)
+};
+
+const output = `// generated from references/words.md and references/patterns.md\n// do not edit by hand. run \`node scripts/generate-site-data.mjs\`.\nwindow.STOP_SLOP_DATA = ${JSON.stringify(data, null, 2)};\n`;
+
+await writeFile(path.join(repoRoot, "docs", "site-data.js"), output);
+console.log("wrote docs/site-data.js");


### PR DESCRIPTION
## Summary
- New single-page site at `docs/` with hero, live slop detector, word tier pills, pattern cards, severity grid, install tabs, and credits for all four cited public repos
- Editorial design system: warm paper + deep ink, Fraunces/Inter/JetBrains Mono, full dark mode, responsive down to 375px
- Client-side detector highlights tier-1/2/3 word hits, bad openers, and structural patterns using the lists in `references/`
- Content quoted verbatim from `SKILL.md`, `references/*.md`, and `ATTRIBUTION.md` — no source files modified
- Enable GitHub Pages with `Source: Deploy from branch → main /docs` after merge

## Test plan
- [ ] Open `docs/index.html` locally (or serve `docs/`) and verify all sections render
- [ ] Toggle the theme button — light ↔ dark persists via localStorage
- [ ] Paste prose into the live detector and confirm flags highlight
- [ ] Click through the install tabs (claude / codex / projects / chat)
- [ ] Confirm mobile layout at ≤720px
- [ ] Enable GitHub Pages and confirm deploy