### PR TITLE
Prepare the upstream contribution to conorbronsdon/avoid-ai-writing

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -229,4 +229,4 @@ AI tells are era-stamped and rotate as model generations change. Delve-era words
 - Date-stamp additions in the Words changelog so stale bans stay visible.
 - Keep a short retired list for bans that start eating natural vocabulary. Watch `ecosystem`, which is literal job language for a Head of Ecosystem.
 
-Last sweep 2026-07-11, against conorbronsdon/avoid-ai-writing v3.15.0, hardikpandya/stop-slop, blader/humanizer, jalaalrd/anti-ai-slop-writing, and Shreya Shankar's plain-writing skill.
+Last sweep 2026-08-04, against conorbronsdon/avoid-ai-writing v3.23.0, hardikpandya/stop-slop, blader/humanizer, jalaalrd/anti-ai-slop-writing, and Shreya Shankar's plain-writing skill. That sweep runs both directions: what the upstream catalogs have that this one lacks, and what this one has that they lack. The return leg is in [upstream/avoid-ai-writing](upstream/avoid-ai-writing).

--- a/upstream/avoid-ai-writing/0001-crypto-launch-genre-patterns.patch
+++ b/upstream/avoid-ai-writing/0001-crypto-launch-genre-patterns.patch
@@ -1,0 +1,619 @@
+From 0ae372691f9a77e9e4e0515c8c16324d858ae952 Mon Sep 17 00:00:00 2001
+From: welttowelt <olivier.freuler@gmail.com>
+Date: Tue, 4 Aug 2026 10:13:10 +0000
+Subject: [PATCH] Add crypto/launch-genre patterns: 12 Tier 3 phrases, two
+ detectors, one judgment rule
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Gaps found running this catalog against a year of daily protocol and launch
+copy — the genre the Tier 3 phrase cluster rule already targets.
+
+- Twelve more Tier 3 phrases, on the existing density and cluster gates.
+  Terms of art (composability, capital efficiency, trustless, real-world
+  assets) held out on purpose: they name mechanisms, and listing them would
+  flag the writers who use them precisely.
+- dramatic-intro: the ad-break reveal ("Enter Aegis.", "Think Figma meets
+  GitHub."). Case-sensitive, sentence-initial, with a stop-list and a
+  sentence-ends-at-the-name anchor so "Enter your API key" stays clean.
+- self-qa-volley: "Is it fast? Yes. Is it cheap? Also yes." The unit written
+  twice, so one pair stays clean; spans spaces and tabs only, so a real FAQ
+  with each question on its own line stays clean.
+- Domain-term collision: judgment-only, CATEGORIES.md section C. A
+  replacement is wrong when the plainer word is already taken.
+
+Catalog 61 -> 64, engine 47 -> 49 types. Five fixtures, each pairing a true
+positive with the must-not-fire case that shaped the rule.
+---
+ CHANGELOG.md                                  | 12 +++
+ README.md                                     |  6 +-
+ SKILL.md                                      | 86 ++++++++++++++++++-
+ detector/CATEGORIES.md                        |  7 +-
+ detector/patterns.js                          | 81 +++++++++++++++++
+ detector/patterns.test.js                     | 72 ++++++++++++++++
+ package.json                                  |  2 +-
+ .../.claude-plugin/plugin.json                |  2 +-
+ .../skills/avoid-ai-writing/SKILL.md          | 86 ++++++++++++++++++-
+ 9 files changed, 345 insertions(+), 9 deletions(-)
+
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+index df1e384..28c452f 100644
+--- a/CHANGELOG.md
++++ b/CHANGELOG.md
+@@ -4,6 +4,18 @@ All notable changes to this project are documented here.
+ 
+ ---
+ 
++## [3.24.0] — 2026-08-04
++
++### Added
++
++- **Twelve more Tier 3 phrases, from a year of daily protocol and launch copy.** `democratizing access to`, `permissionless innovation`, `powering the next generation of`, `purpose-built for`, `first-of-its-kind`, `industry-leading`, `battle-tested`, `unlocking new possibilities`, `mass adoption`, `the future of finance / money / the internet / work`, `bridging the gap between`, `institutional-grade`. Same density and cluster gates as the first ten, so a single use of any of them stays clean. Terms of art were held out on purpose — `composability`, `capital efficiency`, `trustless`, and `real-world assets` name specific mechanisms, and listing them would flag the writers who use them precisely. Every entry that did land is a wrapper: strip it and the sentence loses no checkable claim.
++- **Launch-copy dramatic introduction** (`dramatic-intro`). The ad-break reveal: a build-up sentence, then the product name as its own beat. "Enter Aegis." Plus the pitch-deck analogy form, "Think Figma meets GitHub." The name is the only content in the beat, so the drama carries a sentence with no claim in it. Case-sensitive and sentence-initial; the `Enter` branch subtracts key names and form-field nouns and requires the sentence to end at the name, which keeps it off "Enter your API key", "Enter Y to continue", and "Enter the build directory and run make".
++- **Self-QA volley** (`self-qa-volley`). "Is it fast? Yes. Is it cheap? Also yes." — the model posing the question the reader supposedly has and answering in one flattering word. One pair is ordinary emphasis and stays clean; the pattern is the unit written twice and only fires on the second beat. Real FAQs are the false-positive class and are structurally distinct: they put each question in a heading or list item, so the rule spans spaces and tabs only and stays inside a running paragraph.
++- **Domain-term collision** (judgment-only, no detector `type`). A replacement is wrong when the plainer word is already taken: `proof` and `proof point` as generic business nouns in cryptography writing, `receipts` next to a protocol that emits literal ones, `foundation` in a piece about a named Foundation. Whether a word collides depends on the audience, which is not in the text, so this is skill prose and listed under CATEGORIES.md §C rather than implemented as a regex.
++- Catalog moves to 64 / 112; the engine to 49 `type`s. Five new fixtures, each pairing a true positive with the must-not-fire case that shaped the rule.
++
++---
++
+ ## [3.23.0] — 2026-08-03
+ 
+ ### Added
+diff --git a/README.md b/README.md
+index ed44eb7..e940e73 100644
+--- a/README.md
++++ b/README.md
+@@ -39,8 +39,8 @@ A one-shot "make this sound human" prompt catches the obvious stuff. This skill
+ 
+ - **Structured audit** — returns identified issues with quoted text, the rewrite, a change summary, and a second-pass audit in four discrete sections. You see exactly what changed and why.
+ - **Two-pass detection** — the second pass re-reads the rewrite and catches patterns that survive the first edit: recycled transitions, lingering inflation, copula swaps that snuck through.
+-- **112-entry word replacement table across 3 tiers + 10 Tier 3 phrases** — not vibes-based. Every flagged word has a specific, plainer alternative. "Leverage" → "use." "Commence" → "start." Tier 1 words always flag, Tier 2 words flag when they cluster, Tier 3 words flag only at high density. Tier 1 itself splits into **1A frequency markers** (`delve`, `tapestry`) and **1B clarity edits** (`in order to`, `utilize`) — same fix, but only 1A is evidence about how a passage was produced, and 1B is weighted lower so a wordiness fix cannot push a document toward an AI classification. Tier 3 *phrases* (multi-word boilerplate like "the integration of," "decentralized compute") flag on per-phrase repetition or when 3+ distinct phrases stack in one piece — the LLM-self-varies-boilerplate shape.
+-- **61 pattern categories** — representative examples below, each with before/after. Includes structural detection (hashtag stuffing, bare-NP bullet lists, hedge-stacked predictions), AI-tool fingerprints (placeholders, citation markup, UTM params), rhythm/uniformity checks, conversational-register tells, and writer-side tests. The full catalog lives in [`SKILL.md`](./SKILL.md); this count is enforced against it in CI.
++- **112-entry word replacement table across 3 tiers + 22 Tier 3 phrases** — not vibes-based. Every flagged word has a specific, plainer alternative. "Leverage" → "use." "Commence" → "start." Tier 1 words always flag, Tier 2 words flag when they cluster, Tier 3 words flag only at high density. Tier 1 itself splits into **1A frequency markers** (`delve`, `tapestry`) and **1B clarity edits** (`in order to`, `utilize`) — same fix, but only 1A is evidence about how a passage was produced, and 1B is weighted lower so a wordiness fix cannot push a document toward an AI classification. Tier 3 *phrases* (multi-word boilerplate like "the integration of," "decentralized compute") flag on per-phrase repetition or when 3+ distinct phrases stack in one piece — the LLM-self-varies-boilerplate shape.
++- **64 pattern categories** — representative examples below, each with before/after. Includes structural detection (hashtag stuffing, bare-NP bullet lists, hedge-stacked predictions), AI-tool fingerprints (placeholders, citation markup, UTM params), rhythm/uniformity checks, conversational-register tells, and writer-side tests. The full catalog lives in [`SKILL.md`](./SKILL.md); this count is enforced against it in CI.
+ - **Detect mode** — flag patterns without rewriting. See which flags are real problems vs. judgment calls. Useful when patterns might be intentional or you're auditing content you don't want altered.
+ - **Works across platforms** — one `SKILL.md` runs in Claude Code, Cowork (as a plugin), OpenClaw, and Cursor (as a ported rule). See the install paths below.
+ 
+@@ -177,7 +177,7 @@ Trigger detect mode with: "detect," "flag only," "audit only," "just flag," "sca
+ 
+ ## Pattern reference
+ 
+-> Representative examples from the catalog — not the exhaustive list (that's [`SKILL.md`](./SKILL.md)). The skill's human-facing prose catalog and the [detector engine](./detector/) use **different counts on purpose**: the engine implements 47 `type` categories because it splits the vocabulary tiers and adds stylometric/fingerprint signals (punctuation distribution, function-word entropy, bypass-trick detection) that work as math over a document rather than as a rule you'd look up. The two are mapped in [`detector/CATEGORIES.md`](./detector/CATEGORIES.md); don't "fix" one count to match the other.
++> Representative examples from the catalog — not the exhaustive list (that's [`SKILL.md`](./SKILL.md)). The skill's human-facing prose catalog and the [detector engine](./detector/) use **different counts on purpose**: the engine implements 49 `type` categories because it splits the vocabulary tiers and adds stylometric/fingerprint signals (punctuation distribution, function-word entropy, bypass-trick detection) that work as math over a document rather than as a rule you'd look up. The two are mapped in [`detector/CATEGORIES.md`](./detector/CATEGORIES.md); don't "fix" one count to match the other.
+ 
+ ### Content Patterns
+ 
+diff --git a/SKILL.md b/SKILL.md
+index 73dbdf8..85fd850 100644
+--- a/SKILL.md
++++ b/SKILL.md
+@@ -1,7 +1,7 @@
+ ---
+ name: avoid-ai-writing
+ description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
+-version: 3.23.0
++version: 3.24.0
+ license: MIT
+ compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
+ metadata:
+@@ -263,6 +263,48 @@ Multi-word boilerplate that's individually unobjectionable but stacks heavily in
+ | (sustainable) reward emissions | Cite the emission schedule and the sink |
+ | tokenized incentive structures | Describe the actual mechanism (vesting, gauge, bonded LP, etc.) |
+ | designed for long-term [X] | Cut "designed for" — either it is or it isn't. Then state the property |
++| democratizing access to [X] | Name who could not get X before and can now |
++| permissionless innovation | Say what someone can now build without asking |
++| powering the next generation of [X] | Cut. Name the current generation's limit and what lifts it |
++| purpose-built for [X] | Cut "purpose-built" — state the design constraint it was built around |
++| first-of-its-kind | Name the kind, and what came closest before |
++| industry-leading | Cite the benchmark and the field. Same rule as world-class in Tier 3 |
++| battle-tested | Give the load, the duration, and what broke |
++| unlocking new possibilities | Name one possibility |
++| mass adoption | Give the user count or the threshold you mean |
++| the future of finance / money / the internet / work | Cut the frame and make the claim it stands in for |
++| bridging the gap between (X and Y) | Name both sides and what now passes between them |
++| institutional-grade | Name the requirement being met (custody model, audit, SLA) |
++
++Terms of art are deliberately absent from this table. `composability`, `capital
++efficiency`, `trustless`, and `real-world assets` each name a specific mechanism,
++so listing them would flag the writers who use them precisely. Every entry above
++is a wrapper: strip it and the sentence loses no checkable claim.
++
++### Domain-term collision
++
++- A replacement is wrong when the plainer word is already taken. This skill's
++  tables suggest general-purpose alternatives, and in a technical domain some of
++  them collide with a term that has a literal, load-bearing meaning there. The
++  collision reads worse than the word it replaced, because a domain reader parses
++  the technical sense first and then has to back out of it.
++- Worked case, cryptography and zero-knowledge writing: `proof` and `proof point`
++  as generic business nouns ("the pilot is our proof point"). In this domain a
++  proof is a mathematical object the system produces, so a strategy sentence that
++  borrows the word collides with the one meaning readers cannot ignore. Same for
++  `receipts` in the "show your receipts" sense next to a protocol that emits
++  literal receipts.
++- Fix: use the concrete noun. `evidence`, `demo`, `working example`, `shipped
++  piece`, `public artifact`, `data point`, `something people can inspect`.
++  `evidence` is usually the word the sentence meant.
++- Generalize by asking one question before applying any replacement: does the
++  substitute already mean something specific to this audience? `foundation` in a
++  piece about a named Foundation, `bridge` in cross-chain writing, `witness` in
++  ZK, `oracle` in database writing, `agent` in both distributed-systems and LLM
++  contexts. When it does, pick a different word rather than the table's default.
++- Judgment-only, and it has to be. Whether a word collides depends on the
++  audience, which is not in the text — "the proof is in the pipeline" is a tell
++  in a ZK post and unremarkable in a marketing memo.
+ 
+ ### Template phrases (avoid)
+ 
+@@ -441,6 +483,26 @@ These slot-fill constructions signal that a sentence was generated, not written.
+ - Distinct from the bare "worth [verb]ing" word-table entry (a single weak word inside a sentence) and from infomercial engagement hooks (mid-flow teasers like "The catch?"): this is the whole closing line of a social post.
+ - The fix: say *what* the thing is and *who* it's for, then drop the CTA. "This one is worth your time:" becomes "Sarah's breakdown of why context windows leak — the clearest explanation I've found for anyone debugging RAG pipelines." If you can't name a specific reason, the share doesn't need a sign-off at all; let the link stand on its own.
+ 
++### Launch-copy dramatic introduction
++
++- The ad-break reveal: a build-up sentence about the problem, then the product
++  name dropped as its own one-word beat. "We tried four sequencers and every one
++  fell over at the same place. Enter Aegis." The pitch-deck variant compresses
++  the same move into an analogy — "Think Figma meets GitHub."
++- The name is the only content in the beat. A reader who did not already know
++  what the thing does learns nothing from the reveal, so the drama is carrying a
++  sentence that has no claim in it.
++- Fix: replace the reveal with what the thing does. "Aegis batches the proofs so
++  a single sequencer stall can't hold the queue." For the analogy form, name the
++  property you meant to borrow rather than the two companies.
++- Distinct from **Formulaic openings** (broad context before the point) and from
++  **Infomercial engagement hooks** (mid-flow teasers like "The catch?"). This one
++  stages an entrance for a proper noun.
++- Carve-out: "Enter" opening an instruction is not this rule — "Enter your API
++  key", "Enter Y to continue", "Enter the build directory and run make". The
++  detector requires a capitalized name, subtracts key names and form-field nouns,
++  and requires the sentence to end at the name, since the tell is the fragment.
++
+ ### Emotional flatline
+ - AI claims emotions as a structural crutch without conveying them through the writing: "What surprised me most," "I was fascinated to discover," "What struck me was," "I was excited to learn," "The most interesting part," and the bare section-header variant: "Interesting part of the project:" / "Interesting thing here:" / "Interesting aspect:". The header form drops "the most" but does the same job — pre-announcing significance the writing hasn't earned.
+ - Two problems. First, it's tell-don't-show: if the thing is genuinely surprising, the reader should feel that from the content, not from the writer announcing it. Second, these phrases are massively overused as list introductions and transitions. They're filler wearing an emotion costume.
+@@ -464,6 +526,24 @@ These slot-fill constructions signal that a sentence was generated, not written.
+ ### Rhetorical question openers
+ - "But what does this mean for developers?" / "So why should you care?" / "What's next?" — AI uses rhetorical questions to stall before the actual point. If you know the answer, just say it. Rhetorical questions are earned by strong setup, not dropped as section transitions.
+ 
++### Self-QA volley
++
++- The model interviews itself: it poses the question the reader supposedly has,
++  answers in one word, and repeats. "Is it fast? Yes. Is it cheap? Also yes."
++  One pair is ordinary emphasis. Two in a row is the tell, and the answers run
++  in the subject's favor.
++- The volley skips the work. Each question is chosen because the answer is
++  favorable, so the passage reads as coverage while never touching the question a
++  skeptic would actually ask.
++- Fix: cut the questions and state the claims with their evidence. "It clears a
++  block in under 400ms and costs about a tenth of a cent per proof." If a real
++  objection exists, raise it in full and answer it in full.
++- Distinct from **Rhetorical question openers**, which stall once before a point.
++  This is a repeated question-and-answer beat inside a running paragraph.
++- Carve-out: a genuine FAQ. Real FAQs put each question in a heading or a list
++  item, so the detector only fires when the pairs run inline in the same
++  paragraph, separated by spaces rather than line breaks.
++
+ ### Parenthetical hedging
+ - "(and, increasingly, Z)" / "(or, more precisely, Y)" / "(and perhaps more importantly, W)" — AI inserts parenthetical asides to sound nuanced without committing. If the aside matters, give it its own sentence. If it doesn't, cut it.
+ 
+@@ -592,6 +672,8 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
+ - Em dash frequency (above 1 per 1,000 words)
+ - Generic future-narrative closers ("may become one of the most important narratives…")
+ - Social endorsement closers ("This one is worth your time:", "thank me later")
++- Launch-copy dramatic introductions ("Enter Aegis.", "Think Figma meets GitHub.")
++- Self-QA volleys ("Is it fast? Yes. Is it cheap? Also yes.")
+ - Lingering-attention claims ("the line I keep coming back to," "I can't stop thinking about this")
+ - Narrated candor ("I would rather flag this than let you discover it later", "in the interest of full disclosure")
+ - Hedge-stacked predictions ("could potentially," "may eventually")
+@@ -658,6 +740,8 @@ Rules not listed in the table apply at full strength across all profiles.
+ | Tier 3 phrase clustering | strict | strict | strict | **extra strict** | relaxed | skip |
+ | Future-narrative closers | strict | strict | strict | **extra strict** | skip | skip |
+ | Social endorsement closers | strict (the LinkedIn share-post tell) | strict | strict | strict | skip | relaxed (1 OK in a DM) |
++| Launch-copy dramatic introduction | strict | strict | strict | **extra strict** | skip (an install step is not a reveal) | relaxed |
++| Self-QA volley | strict | strict | relaxed (a real FAQ is the register) | **extra strict** | skip (FAQ sections are docs) | skip |
+ | Hedge-stacked predictions | strict | strict | relaxed ("could" is hedged accuracy) | **extra strict** | relaxed | skip |
+ | Real/actual inflation | strict | strict | strict | **extra strict** | relaxed | skip |
+ | Moral-adjective category errors | strict | strict | relaxed | strict | relaxed | skip |
+diff --git a/detector/CATEGORIES.md b/detector/CATEGORIES.md
+index 889ce11..c7015f3 100644
+--- a/detector/CATEGORIES.md
++++ b/detector/CATEGORIES.md
+@@ -6,14 +6,14 @@ the skill, decide here whether it's regex-detectable (give it a detector `type`)
+ or LLM-only judgment (mark it so). When you add a detector `type`, point it back
+ at the skill section it enforces.
+ 
+-The engine exposes 47 issue `type`s (see `TYPE_LABELS` in `patterns.js`). The
++The engine exposes 49 issue `type`s (see `TYPE_LABELS` in `patterns.js`). The
+ skill has more `###` sections than that — the gap is **not** missing coverage,
+ it's rules that are judgment calls a regex can't make. The three groups below
+ account for every entry on both sides.
+ 
+ Three counts coexist on purpose and should not be forced to match: the README's
+ **pattern-category count** (the human-facing prose catalog, derived from SKILL.md
+-and guarded in CI), the engine's **47 `type`s** (which split the vocabulary tiers
++and guarded in CI), the engine's **49 `type`s** (which split the vocabulary tiers
+ and add stylometric signals), and SKILL.md's `###` sections (which also include
+ writer-side tests with no detectable form). The
+ `categories.test.js` enforces the engine ↔ this-file mapping, and checks every
+@@ -35,6 +35,8 @@ prose statement of the engine `type` total against `TYPE_LABELS`.
+ | `hollow-intensifier` | Hollow intensifier | Filler phrases (intensifiers) |
+ | `generic-conclusion` | Generic conclusion | Generic conclusions |
+ | `social-cta-closer` | Engagement-bait closer | Social endorsement closers |
++| `dramatic-intro` | Launch-copy dramatic introduction | Launch-copy dramatic introduction |
++| `self-qa-volley` | Self-QA volley | Self-QA volley |
+ | `future-narrative` | Generic future narrative | Generic future-narrative closers |
+ | `lets-construction` | "Let's" opener | "Let's" constructions |
+ | `reasoning-artifact` | Reasoning artifact | Reasoning chain artifacts |
+@@ -96,6 +98,7 @@ mistake their absence for a coverage gap:
+ - Moral-adjective category errors (including ontological slop on assumptions, gratuitous universal quantifiers)
+ - Invented contrast-pair mirroring
+ - False ranges
++- Domain-term collision *(whether a replacement collides with a term of art depends on the audience, which is not in the text — "the proof is in the pipeline" is a tell in a ZK post and unremarkable in a marketing memo)*
+ - Notability name-dropping
+ - Vague third-party validation
+ - Self-labeling significance
+diff --git a/detector/patterns.js b/detector/patterns.js
+index c84fa89..04fa880 100644
+--- a/detector/patterns.js
++++ b/detector/patterns.js
+@@ -253,6 +253,27 @@ const AIDetector = (() => {
+     /\b(?:sustainable\s+)?reward\s+emissions?\b/gi,
+     /\btokenized\s+incentive\s+structures?\b/gi,
+     /\bdesigned\s+for\s+long-?term\b/gi,
++    // Second batch, added from a year of daily protocol/launch copy. Same
++    // density gate as the first: each is a phrase a human in this genre can
++    // reasonably write once, and the signal is repetition or stacking.
++    //
++    // Terms of art are deliberately absent. `composability`, `capital
++    // efficiency`, `trustless`, and `real-world assets` all name specific
++    // mechanisms in DeFi writing, so listing them would flag the people who
++    // know what they mean. Every entry below is a wrapper: strip it and the
++    // sentence loses no checkable claim.
++    /\bdemocratiz(?:e|es|ing|ed)\s+access\s+to\b/gi,
++    /\bpermissionless\s+innovation\b/gi,
++    /\bpower(?:s|ing)?\s+the\s+next\s+generation\s+of\b/gi,
++    /\bpurpose-?built\s+for\b/gi,
++    /\bfirst-of-its-kind\b/gi,
++    /\bindustry-?leading\b/gi,
++    /\bbattle-?tested\b/gi,
++    /\bunlock(?:s|ing)?\s+new\s+possibilities\b/gi,
++    /\bmass\s+adoption\b/gi,
++    /\bthe\s+future\s+of\s+(?:finance|money|the\s+internet|work)\b/gi,
++    /\bbridging\s+the\s+gap\s+between\b/gi,
++    /\binstitutional-?grade\b/gi,
+   ];
+ 
+   // O(1) lookup from any token form (hyphenated or dashless) to its canonical
+@@ -315,6 +336,12 @@ const AIDetector = (() => {
+     // strong single-hit social tell that the length divisor would
+     // otherwise wash out on a short LinkedIn-length post.
+     'social-cta-closer': 8,
++    // Launch-copy dramatic introduction and the self-QA volley. Both are
++    // single-hit tells on announcement-length posts, so they carry the same
++    // weight as the other social openers the length divisor would wash out.
++    // The volley already requires two beats before it fires at all.
++    'dramatic-intro': 8,
++    'self-qa-volley': 8,
+     'formulaic-opener': 8,
+     // Speculative scenario opener ("Imagine a world where…"). Weighted like
+     // formulaic-opener: a single strong opener tell the length divisor would
+@@ -823,6 +850,56 @@ const AIDetector = (() => {
+     /\btrust\s+me,?\s+(?:on\s+this|you['’]?ll)\b/gi,
+   ];
+ 
++  // ─── Launch-copy dramatic introduction ─────────────────────────────
++  // The ad-break reveal a model reaches for when asked to announce a
++  // product: a build-up sentence, then the name dropped as its own beat.
++  // "Enter Aegis." / "Think Figma meets GitHub."
++  //
++  // Case-sensitive on purpose. Both branches are sentence-initial reveals,
++  // so the capital is part of the shape, and the `i` flag would drag in
++  // mid-sentence "enter" (a verb people use constantly) and lowercase
++  // "think" (ditto).
++  //
++  // The `Enter` branch carries a stop-list because the same three words
++  // open an instruction: "Enter Y to continue.", "Enter Password.",
++  // "Enter Ctrl-C." Interface labels, key names, and the field nouns a form
++  // asks for are subtracted before the match. It also requires the sentence
++  // to END at the name — the tell is the one-beat fragment, and "Enter the
++  // build directory and run make" is a real instruction that keeps going.
++  // Nothing here rescues a product literally named after a stop-listed word;
++  // that is a recall loss taken on purpose, in the safe direction.
++  //
++  // The `Think X meets Y` branch is pitch-deck shorthand ("Think Stripe
++  // meets Twilio") and needs both sides capitalized, which keeps it off the
++  // ordinary verb ("I think Sarah meets the bar here") — that use is not
++  // sentence-initial and has no second capital.
++  const DRAMATIC_INTRO = [
++    /(?<=^|[.!?\n]\s{0,4})Enter\s+(?!(?:Y|N|Yes|No|Ctrl|Cmd|Alt|Shift|Esc|Del|Tab|Return|Enter|Key|Password|Username|Email|Name|Address|Amount|Value|Your|Their|My|The|A|An|This|That|It|If|When|While|Here|Now|Then)\b)[A-Z][\w.-]*(?:\s+[A-Z][\w.-]*){0,2}\s*[.!]/gm,
++    /(?<=^|[.!?\n]\s{0,4})Think\s+[A-Z][\w.-]*\s+meets\s+[A-Z][\w.-]*/gm,
++  ];
++
++  // ─── Self-QA volley ────────────────────────────────────────────────
++  // "Is it fast? Yes. Is it cheap? Also yes." A model interviewing itself:
++  // it poses the question the reader supposedly has, answers in one word,
++  // and repeats. Each pair looks like ordinary emphasis; the tell is the
++  // repetition, so the pattern below is one unit written twice and only
++  // fires on the second beat.
++  //
++  // FAQ sections are the false-positive class, and they are structurally
++  // different: a real FAQ puts each question in a heading or a list item,
++  // which puts a newline between the question and the next one. This
++  // pattern spans the gap with `[ \t]+` only, so it stays inside a single
++  // running paragraph — the shape a person almost never types twice in a
++  // row, and the shape a launch thread is full of.
++  const SELF_QA_UNIT =
++    "(?:Is|Are|Was|Were|Does|Do|Did|Can|Could|Will|Would|Should|Has|Have)\\s+" +
++    "(?:it|this|that|they|he|she|we|I|you|the\\s+\\w+)\\b[^.?!\\n]{0,60}\\?" +
++    "[ \\t]+(?:Yes|No|Yep|Nope|Absolutely|Definitely|Always|Never|Sometimes|" +
++    "Also\\s+yes|Also\\s+no|Kind\\s+of|Sort\\s+of|Not\\s+really|Not\\s+quite)\\b[.!,]";
++  const SELF_QA_VOLLEY = [
++    new RegExp(`${SELF_QA_UNIT}[ \\t]+${SELF_QA_UNIT}`, 'g'),
++  ];
++
+   // ═══ Helpers ═══════════════════════════════════════════════════════
+ 
+   function tokenize(text) {
+@@ -1068,6 +1145,8 @@ const AIDetector = (() => {
+     issues.push(...matchPatterns(text, FUTURE_NARRATIVE, 'future-narrative', 'high'));
+     issues.push(...matchPatterns(text, REAL_ACTUAL_INFLATION, 'real-actual-inflation', 'medium'));
+     issues.push(...matchPatterns(text, SOCIAL_CTA_CLOSER, 'social-cta-closer', 'high'));
++    issues.push(...matchPatterns(text, DRAMATIC_INTRO, 'dramatic-intro', 'high'));
++    issues.push(...matchPatterns(text, SELF_QA_VOLLEY, 'self-qa-volley', 'high'));
+ 
+     // ── Tier 1 v2: formulaic openers + parenthetical hedges ──────────
+     issues.push(...matchPatterns(text, FORMULAIC_OPENERS, 'formulaic-opener', 'high'));
+@@ -1917,6 +1996,8 @@ const AIDetector = (() => {
+     'future-narrative': 'Generic future narrative',
+     'real-actual-inflation': '"Real/actual" inflation',
+     'social-cta-closer': 'Engagement-bait closer',
++    'dramatic-intro': 'Launch-copy dramatic introduction',
++    'self-qa-volley': 'Self-QA volley',
+     'formulaic-opener': 'Formulaic opener',
+     'speculative-opener': 'Speculative scenario opener',
+     'title-case-header': 'Title Case header',
+diff --git a/detector/patterns.test.js b/detector/patterns.test.js
+index 3e428f0..31b6938 100644
+--- a/detector/patterns.test.js
++++ b/detector/patterns.test.js
+@@ -848,6 +848,78 @@ test('v2: social endorsement closer leaves literal-verb human prose alone', () =
+   }
+ });
+ 
++test('v2: launch-copy dramatic introduction fires on both branches', () => {
++  const variants = [
++    'We tried four different sequencers over eighteen months and every one of them fell over at the same place under load. Enter Aegis.',
++    'The prover pipeline was solid but it still needed a surface that non-engineers could operate without filing a ticket. Think Figma meets GitHub.',
++  ];
++  for (const text of variants) {
++    const r = AIDetector.analyzeText(text);
++    const types = new Set(r.issues.map((i) => i.type));
++    assert.ok(types.has('dramatic-intro'), `expected dramatic-intro on: ${text}`);
++  }
++});
++
++test('v2: dramatic introduction leaves "Enter" instructions alone', () => {
++  // The stop-list, the capitalized-name requirement, and the
++  // sentence-must-end-at-the-name anchor exist for exactly these.
++  const clean = [
++    'Enter your API key in the dashboard and the client will pick it up on the next restart without a redeploy.',
++    'Enter Y to continue. The installer then unpacks the archive into the directory you selected on the previous screen.',
++    'Press Enter. The prompt returns and you can run the next command against the staging cluster right away.',
++    'Enter Ctrl-C. That stops the watcher and the file handles are released before the next test run starts up.',
++    'Enter the build directory and run make, then copy the resulting binary onto the box you are provisioning.',
++    'I think Sarah meets the bar for this role and I would like to move her to the final round this week.',
++  ];
++  for (const text of clean) {
++    const r = AIDetector.analyzeText(text);
++    const types = new Set(r.issues.map((i) => i.type));
++    assert.ok(!types.has('dramatic-intro'), `false positive on instruction: ${text}`);
++  }
++});
++
++test('v2: self-QA volley fires only on the second beat', () => {
++  const twoBeats = 'The rollout took about six weeks end to end. Is it fast? Yes. Is it cheap? Also yes. The migration path is where most of the work actually landed for our team.';
++  const types = new Set(AIDetector.analyzeText(twoBeats).issues.map((i) => i.type));
++  assert.ok(types.has('self-qa-volley'), 'expected self-qa-volley on two consecutive beats');
++
++  // One pair is ordinary emphasis and must stay clean, or the rule fires on
++  // every writer who asks and answers a single question mid-paragraph.
++  const onePair = 'The rollout took about six weeks end to end. Is it fast? Yes. The migration path is where most of the work actually landed for our team this quarter.';
++  const oneTypes = new Set(AIDetector.analyzeText(onePair).issues.map((i) => i.type));
++  assert.ok(!oneTypes.has('self-qa-volley'), 'false positive on a single question-and-answer pair');
++});
++
++test('v2: self-QA volley leaves a real FAQ and a qualified answer alone', () => {
++  const clean = [
++    // A real FAQ breaks each question onto its own line; the rule spans
++    // spaces and tabs only, so the newline keeps it clean.
++    'The doc answers the obvious ones for new operators.\nIs it fast? Yes.\nIs it cheap? Also yes.\nIs it ready? Not yet.',
++    // A qualified answer is a real answer, not a one-word flatterer.
++    'Is it fast? Yes, on the hot path, though the cold start still costs us about four hundred milliseconds on every single deploy we ship.',
++  ];
++  for (const text of clean) {
++    const r = AIDetector.analyzeText(text);
++    const types = new Set(r.issues.map((i) => i.type));
++    assert.ok(!types.has('self-qa-volley'), `false positive on: ${text.slice(0, 48)}`);
++  }
++});
++
++test('v2: second-batch Tier 3 phrases are density-gated, not single-hit', () => {
++  // One use of one phrase must stay clean — the whole point of the tier.
++  const single = 'The custody model is institutional-grade, which for us means the keys sit in an HSM and every withdrawal needs two signers on separate hardware.';
++  const singleTypes = new Set(AIDetector.analyzeText(single).issues.map((i) => i.type));
++  assert.ok(!singleTypes.has('tier3-phrase'), 'false positive on a single new-phrase use');
++
++  // Three distinct phrases stacked is the cluster shape the tier exists for.
++  const cluster = 'Our platform is purpose-built for scale and battle-tested across two market cycles. We are democratizing access to yield that used to sit behind a private bank relationship, and the roadmap runs through mass adoption.';
++  const clusterTypes = new Set(AIDetector.analyzeText(cluster).issues.map((i) => i.type));
++  assert.ok(
++    clusterTypes.has('tier3-phrase-cluster') || clusterTypes.has('tier3-phrase'),
++    'expected the new phrases to reach the Tier 3 phrase cluster'
++  );
++});
++
+ test('v2: trinary output present + FN-biased for ambiguous text', () => {
+   // A plain human bug-report should not get AI_ONLY even if score lifts.
+   const text = 'The build broke again this morning. Rolled back the auth refactor and tests pass now. Still need to figure out why the token refresh path hits a 401 for users on Safari but not Firefox — probably a cookie scope issue but I want to confirm before shipping a fix.';
+diff --git a/package.json b/package.json
+index 3bec239..3a2f073 100644
+--- a/package.json
++++ b/package.json
+@@ -1,6 +1,6 @@
+ {
+   "name": "avoid-ai-writing-detector",
+-  "version": "3.23.0",
++  "version": "3.24.0",
+   "description": "Deterministic detection engine for the Avoid AI Writing skill — pattern + stylometric analysis of AI-generated text.",
+   "license": "MIT",
+   "repository": {
+diff --git a/plugins/avoid-ai-writing/.claude-plugin/plugin.json b/plugins/avoid-ai-writing/.claude-plugin/plugin.json
+index 5d80861..d3413fd 100644
+--- a/plugins/avoid-ai-writing/.claude-plugin/plugin.json
++++ b/plugins/avoid-ai-writing/.claude-plugin/plugin.json
+@@ -1,7 +1,7 @@
+ {
+   "name": "avoid-ai-writing",
+   "description": "Audit & rewrite content to remove AI writing patterns (\"AI-isms\"). Supports detect-only and edit-in-place modes, voice profiles, and iterate-to-convergence.",
+-  "version": "3.23.0",
++  "version": "3.24.0",
+   "author": {
+     "name": "Conor Bronsdon"
+   },
+diff --git a/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md b/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
+index 73dbdf8..85fd850 100644
+--- a/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
++++ b/plugins/avoid-ai-writing/skills/avoid-ai-writing/SKILL.md
+@@ -1,7 +1,7 @@
+ ---
+ name: avoid-ai-writing
+ description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
+-version: 3.23.0
++version: 3.24.0
+ license: MIT
+ compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
+ metadata:
+@@ -263,6 +263,48 @@ Multi-word boilerplate that's individually unobjectionable but stacks heavily in
+ | (sustainable) reward emissions | Cite the emission schedule and the sink |
+ | tokenized incentive structures | Describe the actual mechanism (vesting, gauge, bonded LP, etc.) |
+ | designed for long-term [X] | Cut "designed for" — either it is or it isn't. Then state the property |
++| democratizing access to [X] | Name who could not get X before and can now |
++| permissionless innovation | Say what someone can now build without asking |
++| powering the next generation of [X] | Cut. Name the current generation's limit and what lifts it |
++| purpose-built for [X] | Cut "purpose-built" — state the design constraint it was built around |
++| first-of-its-kind | Name the kind, and what came closest before |
++| industry-leading | Cite the benchmark and the field. Same rule as world-class in Tier 3 |
++| battle-tested | Give the load, the duration, and what broke |
++| unlocking new possibilities | Name one possibility |
++| mass adoption | Give the user count or the threshold you mean |
++| the future of finance / money / the internet / work | Cut the frame and make the claim it stands in for |
++| bridging the gap between (X and Y) | Name both sides and what now passes between them |
++| institutional-grade | Name the requirement being met (custody model, audit, SLA) |
++
++Terms of art are deliberately absent from this table. `composability`, `capital
++efficiency`, `trustless`, and `real-world assets` each name a specific mechanism,
++so listing them would flag the writers who use them precisely. Every entry above
++is a wrapper: strip it and the sentence loses no checkable claim.
++
++### Domain-term collision
++
++- A replacement is wrong when the plainer word is already taken. This skill's
++  tables suggest general-purpose alternatives, and in a technical domain some of
++  them collide with a term that has a literal, load-bearing meaning there. The
++  collision reads worse than the word it replaced, because a domain reader parses
++  the technical sense first and then has to back out of it.
++- Worked case, cryptography and zero-knowledge writing: `proof` and `proof point`
++  as generic business nouns ("the pilot is our proof point"). In this domain a
++  proof is a mathematical object the system produces, so a strategy sentence that
++  borrows the word collides with the one meaning readers cannot ignore. Same for
++  `receipts` in the "show your receipts" sense next to a protocol that emits
++  literal receipts.
++- Fix: use the concrete noun. `evidence`, `demo`, `working example`, `shipped
++  piece`, `public artifact`, `data point`, `something people can inspect`.
++  `evidence` is usually the word the sentence meant.
++- Generalize by asking one question before applying any replacement: does the
++  substitute already mean something specific to this audience? `foundation` in a
++  piece about a named Foundation, `bridge` in cross-chain writing, `witness` in
++  ZK, `oracle` in database writing, `agent` in both distributed-systems and LLM
++  contexts. When it does, pick a different word rather than the table's default.
++- Judgment-only, and it has to be. Whether a word collides depends on the
++  audience, which is not in the text — "the proof is in the pipeline" is a tell
++  in a ZK post and unremarkable in a marketing memo.
+ 
+ ### Template phrases (avoid)
+ 
+@@ -441,6 +483,26 @@ These slot-fill constructions signal that a sentence was generated, not written.
+ - Distinct from the bare "worth [verb]ing" word-table entry (a single weak word inside a sentence) and from infomercial engagement hooks (mid-flow teasers like "The catch?"): this is the whole closing line of a social post.
+ - The fix: say *what* the thing is and *who* it's for, then drop the CTA. "This one is worth your time:" becomes "Sarah's breakdown of why context windows leak — the clearest explanation I've found for anyone debugging RAG pipelines." If you can't name a specific reason, the share doesn't need a sign-off at all; let the link stand on its own.
+ 
++### Launch-copy dramatic introduction
++
++- The ad-break reveal: a build-up sentence about the problem, then the product
++  name dropped as its own one-word beat. "We tried four sequencers and every one
++  fell over at the same place. Enter Aegis." The pitch-deck variant compresses
++  the same move into an analogy — "Think Figma meets GitHub."
++- The name is the only content in the beat. A reader who did not already know
++  what the thing does learns nothing from the reveal, so the drama is carrying a
++  sentence that has no claim in it.
++- Fix: replace the reveal with what the thing does. "Aegis batches the proofs so
++  a single sequencer stall can't hold the queue." For the analogy form, name the
++  property you meant to borrow rather than the two companies.
++- Distinct from **Formulaic openings** (broad context before the point) and from
++  **Infomercial engagement hooks** (mid-flow teasers like "The catch?"). This one
++  stages an entrance for a proper noun.
++- Carve-out: "Enter" opening an instruction is not this rule — "Enter your API
++  key", "Enter Y to continue", "Enter the build directory and run make". The
++  detector requires a capitalized name, subtracts key names and form-field nouns,
++  and requires the sentence to end at the name, since the tell is the fragment.
++
+ ### Emotional flatline
+ - AI claims emotions as a structural crutch without conveying them through the writing: "What surprised me most," "I was fascinated to discover," "What struck me was," "I was excited to learn," "The most interesting part," and the bare section-header variant: "Interesting part of the project:" / "Interesting thing here:" / "Interesting aspect:". The header form drops "the most" but does the same job — pre-announcing significance the writing hasn't earned.
+ - Two problems. First, it's tell-don't-show: if the thing is genuinely surprising, the reader should feel that from the content, not from the writer announcing it. Second, these phrases are massively overused as list introductions and transitions. They're filler wearing an emotion costume.
+@@ -464,6 +526,24 @@ These slot-fill constructions signal that a sentence was generated, not written.
+ ### Rhetorical question openers
+ - "But what does this mean for developers?" / "So why should you care?" / "What's next?" — AI uses rhetorical questions to stall before the actual point. If you know the answer, just say it. Rhetorical questions are earned by strong setup, not dropped as section transitions.
+ 
++### Self-QA volley
++
++- The model interviews itself: it poses the question the reader supposedly has,
++  answers in one word, and repeats. "Is it fast? Yes. Is it cheap? Also yes."
++  One pair is ordinary emphasis. Two in a row is the tell, and the answers run
++  in the subject's favor.
++- The volley skips the work. Each question is chosen because the answer is
++  favorable, so the passage reads as coverage while never touching the question a
++  skeptic would actually ask.
++- Fix: cut the questions and state the claims with their evidence. "It clears a
++  block in under 400ms and costs about a tenth of a cent per proof." If a real
++  objection exists, raise it in full and answer it in full.
++- Distinct from **Rhetorical question openers**, which stall once before a point.
++  This is a repeated question-and-answer beat inside a running paragraph.
++- Carve-out: a genuine FAQ. Real FAQs put each question in a heading or a list
++  item, so the detector only fires when the pairs run inline in the same
++  paragraph, separated by spaces rather than line breaks.
++
+ ### Parenthetical hedging
+ - "(and, increasingly, Z)" / "(or, more precisely, Y)" / "(and perhaps more importantly, W)" — AI inserts parenthetical asides to sound nuanced without committing. If the aside matters, give it its own sentence. If it doesn't, cut it.
+ 
+@@ -592,6 +672,8 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
+ - Em dash frequency (above 1 per 1,000 words)
+ - Generic future-narrative closers ("may become one of the most important narratives…")
+ - Social endorsement closers ("This one is worth your time:", "thank me later")
++- Launch-copy dramatic introductions ("Enter Aegis.", "Think Figma meets GitHub.")
++- Self-QA volleys ("Is it fast? Yes. Is it cheap? Also yes.")
+ - Lingering-attention claims ("the line I keep coming back to," "I can't stop thinking about this")
+ - Narrated candor ("I would rather flag this than let you discover it later", "in the interest of full disclosure")
+ - Hedge-stacked predictions ("could potentially," "may eventually")
+@@ -658,6 +740,8 @@ Rules not listed in the table apply at full strength across all profiles.
+ | Tier 3 phrase clustering | strict | strict | strict | **extra strict** | relaxed | skip |
+ | Future-narrative closers | strict | strict | strict | **extra strict** | skip | skip |
+ | Social endorsement closers | strict (the LinkedIn share-post tell) | strict | strict | strict | skip | relaxed (1 OK in a DM) |
++| Launch-copy dramatic introduction | strict | strict | strict | **extra strict** | skip (an install step is not a reveal) | relaxed |
++| Self-QA volley | strict | strict | relaxed (a real FAQ is the register) | **extra strict** | skip (FAQ sections are docs) | skip |
+ | Hedge-stacked predictions | strict | strict | relaxed ("could" is hedged accuracy) | **extra strict** | relaxed | skip |
+ | Real/actual inflation | strict | strict | strict | **extra strict** | relaxed | skip |
+ | Moral-adjective category errors | strict | strict | relaxed | strict | relaxed | skip |
+-- 
+2.43.0
+

--- a/upstream/avoid-ai-writing/ISSUE-pattern-gaps.md
+++ b/upstream/avoid-ai-writing/ISSUE-pattern-gaps.md
@@ -1,0 +1,219 @@
+Title: Eight pattern gaps from the crypto/launch genre, each needing a call before anything is written
+
+---
+
+Follow-up to #54. The three rules I was confident about are in a PR. These eight
+are the ones where CONTRIBUTING says to open an issue first, either because the
+false-positive class is a genuine human habit or because the rule would touch a
+threshold that already ships. One comment rather than eight issues; happy to
+split any of them out.
+
+Format for each: the shape, an example from the genre, what the nearest existing
+rule does and does not cover, and the call I am asking for.
+
+---
+
+### 1. Dash substitutes that survive a de-slop pass
+
+**Shape.** A spaced hyphen or a spaced en dash doing em-dash duty, or a comma
+splice carrying the old dash rhythm.
+
+> The prover is the bottleneck - not the sequencer - and that changed the whole
+> roadmap.
+
+> The prover is the bottleneck – not the sequencer – and that changed the whole
+> roadmap.
+
+**Existing coverage.** The Formatting rule names `—` and `--`, and the detector's
+rate check counts both. Neither the spaced hyphen nor the en dash is counted.
+
+**Why it matters here specifically.** This is the artifact this repo's own advice
+produces. Someone told to strip em dashes swaps the character and keeps the
+clause structure, and the result reads exactly as before to anyone who was
+reading the structure rather than the glyph.
+
+**The call.** Two options, and I do not think it is mine to pick. Either count
+substitutes toward the existing 1-per-1,000 budget — which changes a shipping
+threshold and needs an FP run before it lands — or leave the rate alone and
+handle the swap as skill prose under Formatting. The en dash is the awkward half:
+spaced en dash is the standard dash in British and Oxford house style, so a rate
+rule that counts it will fire on correct human typography from a whole publishing
+tradition.
+
+---
+
+### 2. Decorative colon reveal in running prose
+
+**Shape.** A short noun-phrase label, a colon, then the payload, mid-paragraph.
+
+> The promise: proofs cheap enough to post every block.
+
+> The takeaway: nobody has solved the data-availability cost yet.
+
+> The point is simple: the fee market is the product.
+
+**Existing coverage.** List-label periods handles the bullet case, and in the
+opposite direction — it says a human writes the colon where the LLM writes a
+period. The running-prose case is the reverse move and is not covered: in a
+paragraph, the colon-reveal is the tell and a full clause is the fix.
+
+**The call.** Whether the two rules can coexist without contradicting each other
+in a reader's head. They are consistent (bullet label wants a colon, prose
+sentence wants a clause) but the pair needs to be written carefully or it reads
+as the skill flip-flopping. Also worth deciding whether the exemption list is
+worth it: short social posts do use a genuine label opener ("shipped: the
+migration doc"), which is content, not staging.
+
+---
+
+### 3. Transformation crutch
+
+**Shape.** Summary glue that asserts a state change without naming an actor, a
+threshold, or a consequence.
+
+> Once custody moves on-chain, the compliance question turns into an
+> engineering question.
+
+> The risk becomes real when the bridge is the only exit.
+
+> It stops being a pile of notes and starts being a system.
+
+**Existing coverage.** The split-sentence negation rule quotes "stops being X and
+starts being Y", but as an instance of the contrast structure. The bare
+transformation with no contrast in it — "turns into", "becomes real" — has no
+home.
+
+**Fix I use.** Name the action, the threshold, or the party. "Once custody moves
+on-chain, the compliance team has to review the contract, not the counterparty."
+
+**The call.** This is judgment-only in my read: "turns into" is ordinary English
+and a regex on it would flag half the technical writing in existence. If you
+agree, it is a SKILL.md paragraph and a §C line. If you think there is a
+detectable sub-shape, I would rather you scope it than guess.
+
+---
+
+### 4. Dramatized contrast against the crowd
+
+**Shape.** A true fact with a trailing clause inventing a lagging crowd.
+
+> We shipped it in 2022, while everyone else was still debating timelines.
+
+> Built it in a weekend, while the industry wrote thinkpieces.
+
+**Existing coverage.** "Forced contrarianism" is in the never-inject list — a
+constraint on the rewriter, not a detection on the text. So the skill will not
+add one, but it also will not flag one the author wrote.
+
+**Why it is a tell and not just a brag.** The crowd is never named and its
+position is never quoted. The clause is a strawman with a date attached, which is
+what separates it from a real competitive claim ("Polygon shipped theirs in
+2023").
+
+**The call.** Whether a never-inject entry should imply a detection entry. There
+may be a general principle here worth deciding once, since the same asymmetry
+applies to fake first person and manufactured stakes.
+
+---
+
+### 5. Credential-announcing openers
+
+**Shape.**
+
+> As a protocol engineer, I can tell you the fee math does not work.
+
+> Speaking as someone who has run a validator since 2021, this is optimistic.
+
+**Existing coverage.** None that I can find. Nearest neighbours are notability
+name-dropping (piling on others' credentials) and vague third-party validation
+(an unnamed authority). This is the first-person version: the writer's own
+credential, front-loaded, doing the work the argument should do.
+
+**Carve-out that makes it hard.** The credential is sometimes the whole content —
+a disclosure ("as the author of the EIP this thread is about"), or the answer to
+a question about standing. Same structure as your conflict-of-interest carve-out
+under narrated candor.
+
+**The call.** Whether that carve-out can be drawn tightly enough to be worth a
+rule.
+
+---
+
+### 6. Fake-casual staging
+
+**Shape.** The costume a model puts on when asked for lowercase-casual social
+voice. Three sub-shapes:
+
+- label-prefix openers: `hot take:`, `unpopular opinion:`, `fun fact:`,
+  `pro tip:`, `PSA:`, `hard truth:`, `friendly reminder:`
+- one-word verdict closers: `wild.`, `insane.`, `unhinged.`
+- stage directions: `*checks notes*`, `*chef's kiss*`, `*mic drop*`
+
+**Existing coverage.** Infomercial engagement hooks covers `Plot twist:` and the
+fake-candid register (`Real talk:`, `Honestly?`, `Look,`). The rest of the family
+is not listed.
+
+**Why I did not put this in the PR.** Every one of these is a real human internet
+idiom that humans invented and models copy. A flat regex on `hot take:` flags
+ordinary Twitter. I think the honest version is a cluster rule — two or more
+staging moves in one short post — or nothing, and a cluster rule needs a
+threshold I would rather not pick unilaterally.
+
+**The call.** Cluster rule, prose-only, or drop it.
+
+---
+
+### 7. Model-average claim
+
+**Shape.** A claim that is true, safe, and centred on the field's consensus,
+carrying no tension, constraint, or tradeoff.
+
+> AI improves developer productivity.
+
+> Privacy is important for institutional adoption.
+
+> Agents need verifiable identity.
+
+**Existing coverage.** Nothing directly. The treadmill-effect test ("what's
+actually new here?") is adjacent but asks about a paragraph restating its own
+premise; this is about a claim that never had a stake in the first place.
+
+**Fix I use.** Add the specific tension, constraint, tradeoff, or decision that
+makes the claim worth saying. "Privacy is important for institutional adoption"
+→ name the compliance bottleneck or the disclosure boundary.
+
+**The call.** This is a writer-side test in the same family as
+paragraph-reshuffle immunity, so it may belong there rather than in the flagging
+catalog.
+
+---
+
+### 8. AI-first anchoring — the one I would most like your read on
+
+**Shape.** Not a phrase. The model wrote the first draft, a human cleaned it, and
+the finished piece still sits at the model's default centre: its angle, its
+structure, its examples, its rhythm. Every flag clears and the piece is still
+the model's.
+
+**Existing coverage.** The "Never inject these" section is the mirror image of
+this — constraints on the editor, justified by provenance being invisible to any
+pattern. That section already argues the key point ("the difference is
+provenance, which no pattern can see"). What is missing is the other half: what
+to do when provenance runs the other way and the *source* is the model's.
+
+**What I run.** When AI supplied the first shape, or provenance is unknown and
+the writer is an expert, line edits are the wrong move — they preserve the shape.
+Instead: name the human claim in one sentence, rebuild the structure from it,
+then write. For expert, founder, and voice-sensitive work the default is human
+draft first, AI critique second.
+
+**The call.** Whether this belongs in this repo at all. It is a pipeline rule
+rather than a text rule, and it may be out of scope for a skill that audits text
+it is handed. But it is the single largest structural difference between the two
+catalogs, so I would rather ask than assume.
+
+---
+
+Happy to PR any of these once you have called them, or to drop the ones you have
+already considered and rejected. If it is easier, mark the ones you want and I
+will work through them in that order.

--- a/upstream/avoid-ai-writing/PULL_REQUEST.md
+++ b/upstream/avoid-ai-writing/PULL_REQUEST.md
@@ -1,0 +1,95 @@
+Title: Add crypto/launch-genre patterns: 12 Tier 3 phrases, two detectors, one judgment rule
+
+---
+
+## Summary
+
+Taking up the offer from #54. These are the gaps that showed up running this
+catalog against a year of daily protocol and launch copy — the genre the Tier 3
+phrase cluster rule already targets, which is why the misses cluster there.
+
+**Twelve more Tier 3 phrases**, on the existing density and per-phrase gates:
+`democratizing access to`, `permissionless innovation`, `powering the next
+generation of`, `purpose-built for`, `first-of-its-kind`, `industry-leading`,
+`battle-tested`, `unlocking new possibilities`, `mass adoption`, `the future of
+finance / money / the internet / work`, `bridging the gap between`,
+`institutional-grade`.
+
+Four candidates were held out on purpose and the reason is in the SKILL.md prose
+under the table: `composability`, `capital efficiency`, `trustless`, and
+`real-world assets` each name a specific mechanism in DeFi writing, so listing
+them would flag the people who use them precisely. Every phrase that did land is
+a wrapper — strip it and the sentence loses no checkable claim. That is the test
+I used to sort the list.
+
+**`dramatic-intro`** — the ad-break reveal. A build-up sentence about the
+problem, then the product name dropped as its own beat: "We tried four
+sequencers and every one fell over at the same place. Enter Aegis." Plus the
+pitch-deck analogy form, "Think Figma meets GitHub." The name is the only content
+in the beat, so the drama is carrying a sentence with no claim in it.
+
+Precision work: case-sensitive and sentence-initial on both branches. The `Enter`
+branch carries a stop-list (key names, form-field nouns, determiners) and
+requires the sentence to *end* at the name, because the tell is the fragment.
+That keeps it off "Enter your API key", "Enter Y to continue", "Enter Ctrl-C",
+and "Enter the build directory and run make" — all of which are in the
+must-not-fire fixture. A product literally named after a stop-listed word is
+missed; that is a recall loss taken in the safe direction.
+
+**`self-qa-volley`** — "Is it fast? Yes. Is it cheap? Also yes." The model
+interviewing itself: it poses the question the reader supposedly has, answers in
+one word, and repeats. Each question is picked because the answer is favorable,
+so the passage reads as coverage while never touching what a skeptic would ask.
+
+Precision work: the pattern is the unit written twice, so a single
+question-and-answer pair — ordinary emphasis — stays clean. The gap between the
+two beats matches `[ \t]+` only, which is what separates this from the
+false-positive class: a real FAQ puts each question in a heading or a list item,
+so there is a newline between them. Both cases are fixtures.
+
+**Domain-term collision** — judgment-only, listed under CATEGORIES.md §C. A
+replacement is wrong when the plainer word is already taken. `proof` and `proof
+point` as generic business nouns in cryptography writing collide with the
+mathematical object the system actually produces; `receipts` in the "show your
+receipts" sense collides with a protocol that emits literal ones; `foundation`
+collides in a piece about a named Foundation. Whether a word collides depends on
+the audience, which is not in the text — "the proof is in the pipeline" is a tell
+in a ZK post and unremarkable in a marketing memo. So it is skill prose, not a
+regex.
+
+Catalog 61 → 64, engine 47 → 49 `type`s, version 3.24.0.
+
+Eight further gaps that need a judgment call before anything is written are in a
+separate issue rather than in this PR, per CONTRIBUTING.
+
+## Checklist
+
+- [x] `npm test` passes (engine fixtures + `CATEGORIES.md` contract check)
+- [x] If I added a detector `type`: it's documented in `detector/CATEGORIES.md` and has a fixture in `detector/patterns.test.js` (a true positive **and** a must-not-fire case)
+- [x] If I added a judgment-only rule: it's listed under "Skill-only" in `detector/CATEGORIES.md`
+- [x] I considered false positives and added carve-outs for legitimate human writing
+- [x] Any factual claim about how AI or humans write (e.g. "ChatGPT emits X", "humans rarely do Y") cites a source
+- [x] The prose I added passes the skill's own audit (no AI-writing tells, terse bullets, no hollow intensifiers)
+- [x] `CHANGELOG.md` entry added under a dated `## [X.Y.Z]` heading, and `SKILL.md` `version:` bumped if a rule changed
+
+Notes on two of those boxes:
+
+**Sources.** No frequency claim is made anywhere in this diff, so there is
+nothing to cite. The phrase list is described as what it is — phrases observed
+in one genre over a year of daily reading — and the two new categories are
+argued from what the sentence does to a reader, not from a ratio. If you would
+rather the phrase list carry a corpus measurement before it ships, say so and I
+will run it against whatever machine corpus you want to point at; `npm run fp`
+is already there.
+
+**Self-audit.** `npm run self-scan:check` passes with the new prose in place.
+The one edit it prompted: a draft of the self-QA section said the answers are
+"always the ones that flatter the subject", which is the gratuitous universal
+quantifier this repo flags under moral-adjective category errors. It now reads
+"the answers run in the subject's favor."
+
+## Also run
+
+- `bash scripts/check-pattern-count.sh` — 64 categories, 112 word entries
+- `bash scripts/sync-plugin-skill.sh` — plugin copy and `plugin.json` regenerated
+- `npm run self-scan:check` — every document inside its budget

--- a/upstream/avoid-ai-writing/README.md
+++ b/upstream/avoid-ai-writing/README.md
@@ -1,0 +1,60 @@
+# Upstream contribution: conorbronsdon/avoid-ai-writing
+
+Conor closed [#54](https://github.com/conorbronsdon/avoid-ai-writing/issues/54)
+with an invitation to send back the patterns this repo's merged catalog has and
+that one lacks, since the daily publishing here sits in the genre their Tier 3
+phrase cluster rule targets. This directory holds what goes back.
+
+Two pieces, matching the two levels they asked for:
+
+| File | What it is |
+|---|---|
+| `0001-crypto-launch-genre-patterns.patch` | A commit against `main`, tests passing. Twelve Tier 3 phrases, two detector categories, one judgment-only rule. |
+| `PULL_REQUEST.md` | The PR body, filled against their `.github/PULL_REQUEST_TEMPLATE.md`. |
+| `ISSUE-pattern-gaps.md` | Eight more gaps with examples, each one a judgment call their CONTRIBUTING says to raise as an issue first. |
+
+## What the patch changes
+
+- **Twelve more Tier 3 phrases.** `democratizing access to`, `permissionless
+  innovation`, `powering the next generation of`, `purpose-built for`,
+  `first-of-its-kind`, `industry-leading`, `battle-tested`, `unlocking new
+  possibilities`, `mass adoption`, `the future of finance / money / the internet
+  / work`, `bridging the gap between`, `institutional-grade`. Same density and
+  cluster gates as the existing ten.
+- **`dramatic-intro`** — the ad-break reveal. "Enter Aegis." / "Think Figma
+  meets GitHub."
+- **`self-qa-volley`** — "Is it fast? Yes. Is it cheap? Also yes."
+- **Domain-term collision** — judgment-only, listed under CATEGORIES.md §C. A
+  replacement is wrong when the plainer word is already taken in the domain.
+
+Catalog 61 → 64, engine 47 → 49 `type`s.
+
+## Submitting it
+
+Their repo is not attached to this session, so the patch was built and tested
+against a fresh clone rather than pushed. To send it:
+
+```bash
+git clone https://github.com/<your-fork>/avoid-ai-writing.git
+cd avoid-ai-writing
+git checkout -b crypto-genre-patterns
+git am /path/to/0001-crypto-launch-genre-patterns.patch
+npm test
+bash scripts/check-pattern-count.sh
+npm run self-scan:check
+git push -u origin crypto-genre-patterns
+```
+
+Then open the PR with `PULL_REQUEST.md` as the body, and file
+`ISSUE-pattern-gaps.md` separately.
+
+## Checks run before the patch was exported
+
+All against upstream `cf60f76` (`docs: refresh repository guidance (#106)`):
+
+- `npm test` — detector fixtures, CATEGORIES.md contract, validator, corpus
+  helpers, style checks. Green, including the five new fixtures.
+- `bash scripts/check-pattern-count.sh` — 64 categories, 112 word entries.
+- `bash scripts/sync-plugin-skill.sh` — plugin copy and `plugin.json` version
+  regenerated from the root `SKILL.md` (3.24.0).
+- `npm run self-scan:check` — every document still inside its score budget.


### PR DESCRIPTION
Conor closed [avoid-ai-writing#54](https://github.com/conorbronsdon/avoid-ai-writing/issues/54) asking for the patterns this catalog has and that one lacks, since the daily publishing here sits in the genre their Tier 3 phrase cluster rule targets. This is the return leg of the catalog sweep.

Nothing in this PR changes how this skill behaves. It adds `upstream/avoid-ai-writing/` — a tested patch against their `main` plus the two bodies to post with it — and re-dates the sweep line in `SKILL.md`.

## What goes upstream

**A patch** (`0001-crypto-launch-genre-patterns.patch`), built against `cf60f76`:

- **Twelve more Tier 3 phrases** on their existing density and cluster gates: `democratizing access to`, `permissionless innovation`, `powering the next generation of`, `purpose-built for`, `first-of-its-kind`, `industry-leading`, `battle-tested`, `unlocking new possibilities`, `mass adoption`, `the future of finance / money / the internet / work`, `bridging the gap between`, `institutional-grade`. Terms of art (`composability`, `capital efficiency`, `trustless`, `real-world assets`) were held out on purpose — they name mechanisms, and listing them would flag the writers who use them precisely.
- **`dramatic-intro`** — the ad-break reveal. "Enter Aegis." / "Think Figma meets GitHub." Case-sensitive and sentence-initial, with a stop-list and a sentence-ends-at-the-name anchor so "Enter your API key" and "Enter the build directory and run make" stay clean.
- **`self-qa-volley`** — "Is it fast? Yes. Is it cheap? Also yes." The unit written twice, so one pair stays clean; the gap between beats matches spaces and tabs only, so a real FAQ with each question on its own line stays clean.
- **Domain-term collision**, judgment-only: a replacement is wrong when the plainer word is already taken. `proof` in ZK writing, `receipts` next to a protocol emitting literal ones, `foundation` in a piece about a named Foundation.

Their catalog goes 61 → 64, engine 47 → 49 `type`s, version 3.24.0.

**An issue** (`ISSUE-pattern-gaps.md`) for eight further gaps that their CONTRIBUTING says to raise before writing code, each with examples and the specific call being asked for: dash substitutes that survive a de-slop pass (the artifact their own rule produces), decorative colon reveals in running prose, transformation crutch, dramatized contrast against the crowd, credential-announcing openers, fake-casual staging, model-average claims, and AI-first anchoring.

## Verification

Run in a fresh clone of upstream with the patch applied:

| Check | Result |
|---|---|
| `npm test` | green, including five new fixtures |
| `bash scripts/check-pattern-count.sh` | 64 categories, 112 word entries |
| `bash scripts/sync-plugin-skill.sh` | plugin copy + `plugin.json` regenerated |
| `npm run self-scan:check` | every document inside its budget |

Each new fixture pairs a true positive with the must-not-fire case that shaped the rule. The self-scan caught one thing in my own prose: a draft said the self-QA answers are "always the ones that flatter the subject," which is the gratuitous universal quantifier their catalog flags. It now reads "the answers run in the subject's favor."

## Why it is a patch and not a pushed branch

`conorbronsdon/avoid-ai-writing` is not attached to this session and cannot be added to it, so the work was built and tested against a fresh clone rather than pushed to a fork. `upstream/avoid-ai-writing/README.md` has the `git am` sequence to send it.

## Draft because

The upstream PR and issue have not been filed yet. Merging this is the record that they are ready to go, not that they have gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TB43KKB4HKnrTUzoFMZ9ng

---
_Generated by [Claude Code](https://claude.ai/code/session_01TB43KKB4HKnrTUzoFMZ9ng)_